### PR TITLE
Issues/9/k ne filter

### DIFF
--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -1,0 +1,36 @@
+from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.types import BooleanType
+#from astropy.time import Time
+
+import pandas as pd
+
+@pandas_udf(BooleanType(), PandasUDFType.SCALAR)
+def kn_candidates(#jd, 
+                  #cdsxmatch, 
+                  drb, classtar) -> pd.Series:
+    """ Return alerts considered as KN candidates
+    
+    Parameters
+    ----------
+    cdsxmatch: Spark DataFrame Column
+        Column containing the cross-match values
+    drb: Spark DataFrame Column
+        Column containing the Deep-Learning Real Bogus score
+    classtar: Spark DataFrame Column
+        Column containing the sextractor score
+    Returns
+    ----------
+    out: pandas.Series of bool
+        Return a Pandas DataFrame with the appropriate flag:
+        false for bad alert, and true for good alert.
+    """
+    high_drb = drb.astype(float) > 0.5
+    high_classtar = classtar.astype(float) > 0.4
+    #recent_data = Time.now().jd-jd.astype(float) <0.25
+    
+    # keep_cds = \
+    #     ["Unknown", "Transient"]
+
+    f_kn = high_drb & high_classtar #& recent_data #& cdsxmatch.isin(keep_cds)
+
+    return f_kn

--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -1,13 +1,10 @@
 from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.types import BooleanType
-#from astropy.time import Time
 
 import pandas as pd
 
 @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
-def kn_candidates(#jd, 
-                  #cdsxmatch, 
-                  drb, classtar) -> pd.Series:
+def kn_candidates(kn_score,drb, classtar, jd, ndethist, jdstarthist,cdsxmatch, ) -> pd.Series:
     """ Return alerts considered as KN candidates
     
     Parameters
@@ -18,19 +15,52 @@ def kn_candidates(#jd,
         Column containing the Deep-Learning Real Bogus score
     classtar: Spark DataFrame Column
         Column containing the sextractor score
+    kn_score: Spark DataFrame Column
+        Column containing the kilonovae score
+    jd: Spark DataFrame Column
+        Column containing observation Julian dates at start of exposure [days]
+    ndethist: Spark DataFrame Column
+        Column containing the number of prior detections (with a theshold of 3 sigma)
+    jdstarthist: Spark DataFrame Column
+        Column containing earliest Julian dates of epoch corresponding to ndethist [days]
     Returns
     ----------
     out: pandas.Series of bool
         Return a Pandas DataFrame with the appropriate flag:
         false for bad alert, and true for good alert.
     """
+    
+    high_kn_score = kn_score.astype(float) > 0.5
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
-    #recent_data = Time.now().jd-jd.astype(float) <0.25
+    new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
+    small_detection_history = ndethist.astype(float) < 20
     
-    # keep_cds = \
-    #     ["Unknown", "Transient"]
+    
+    list_simbad_galaxies = [
+        "galaxy",
+        "Galaxy",
+        "EmG",
+        "Seyfert",
+        "Seyfert_1",
+        "Seyfert_2",
+        "BlueCompG",
+        "StarburstG",
+        "LSB_G",
+        "HII_G",
+        "High_z_G",
+        "GinPair",
+        "GinGroup",
+        "BClG",
+        "GinCl",
+        "PartofG",
+    ]
+    
+    
+    keep_cds = \
+        ["Unknown", "Transient","Fail"] + list_simbad_galaxies
 
-    f_kn = high_drb & high_classtar #& recent_data #& cdsxmatch.isin(keep_cds)
+    f_kn = high_kn_score & high_drb & high_classtar & new_detection
+    f_kn = f_kn & small_detection_history & cdsxmatch.isin(keep_cds)
 
     return f_kn

--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -4,7 +4,7 @@ from pyspark.sql.types import BooleanType
 import pandas as pd
 
 @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
-def kn_candidates(kn_score, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch) -> pd.Series:
+def kn_candidates(knscore, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch) -> pd.Series:
     """ Return alerts considered as KN candidates
     
     Parameters
@@ -15,7 +15,7 @@ def kn_candidates(kn_score, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch)
         Column containing the Deep-Learning Real Bogus score
     classtar: Spark DataFrame Column
         Column containing the sextractor score
-    kn_score: Spark DataFrame Column
+    knscore: Spark DataFrame Column
         Column containing the kilonovae score
     jd: Spark DataFrame Column
         Column containing observation Julian dates at start of exposure [days]
@@ -30,7 +30,7 @@ def kn_candidates(kn_score, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch)
         false for bad alert, and true for good alert.
     """
     
-    high_kn_score = kn_score.astype(float) > 0.5
+    high_knscore = knscore.astype(float) > 0.5
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
@@ -60,7 +60,7 @@ def kn_candidates(kn_score, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch)
     keep_cds = \
         ["Unknown", "Transient","Fail"] + list_simbad_galaxies
 
-    f_kn = high_kn_score & high_drb & high_classtar & new_detection
+    f_kn = high_knscore & high_drb & high_classtar & new_detection
     f_kn = f_kn & small_detection_history & cdsxmatch.isin(keep_cds)
 
     return f_kn

--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -4,7 +4,7 @@ from pyspark.sql.types import BooleanType
 import pandas as pd
 
 @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
-def kn_candidates(kn_score,drb, classtar, jd, ndethist, jdstarthist,cdsxmatch, ) -> pd.Series:
+def kn_candidates(kn_score, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch) -> pd.Series:
     """ Return alerts considered as KN candidates
     
     Parameters
@@ -19,10 +19,10 @@ def kn_candidates(kn_score,drb, classtar, jd, ndethist, jdstarthist,cdsxmatch, )
         Column containing the kilonovae score
     jd: Spark DataFrame Column
         Column containing observation Julian dates at start of exposure [days]
-    ndethist: Spark DataFrame Column
-        Column containing the number of prior detections (with a theshold of 3 sigma)
     jdstarthist: Spark DataFrame Column
         Column containing earliest Julian dates of epoch corresponding to ndethist [days]
+    ndethist: Spark DataFrame Column
+        Column containing the number of prior detections (with a theshold of 3 sigma)
     Returns
     ----------
     out: pandas.Series of bool


### PR DESCRIPTION
The thresholds are still to be discussed.
We can make the following observations:
- As expected, few objects have a high ` kn_score`. The threshold of 0.5 seems reasonable for the time being.
- `classtar`and `drb`are not selective among the cuts, as they are usually pretty high among the alerts of high `kn_score`.
- `ndethist`and `jd - jdstarthist`are very selective, as the values of `ndethist` is usually around 1e3, and `jd - jdstarthist` around 30-300. On the 23 march 2021 only one alert passed the cuts.

More tests will be done in the upcoming days.