### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/fink_filters/__init__.py
+++ b/fink_filters/__init__.py
@@ -12,4 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://fink-broker.readthedocs.io/en/latest/",
     packages=setuptools.find_packages(),
+    package_data={
+        'fink_filters': [
+            'data/mangrove_filtered.csv'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
### 0.2.6 to 0.2.7

- New kilonova filters (#18 )
- Add package data in the pip installer (for the mangrove catalog)

Thanks @JulietteVl for the good work!