### PR TITLE
Remove mangrove galaxy id

### DIFF
--- a/fink_filters/filter_early_kn_candidates/filter.py
+++ b/fink_filters/filter_early_kn_candidates/filter.py
@@ -32,10 +32,9 @@ from fink_science.conversion import dc_mag
 
 @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
 def early_kn_candidates(
-        objectId, drb, classtar, jd,
-        jdstarthist, ndethist, cdsxmatch, fid,
-        magpsf, sigmapsf, magnr, sigmagnr,
-        magzpsci, isdiffpos, ra, dec, roid, field) -> pd.Series:
+        objectId, drb, classtar, jd, jdstarthist, ndethist, cdsxmatch, fid,
+        magpsf, sigmapsf, magnr, sigmagnr, magzpsci, isdiffpos, ra, dec, roid,
+        field) -> pd.Series:
     """
     Return alerts considered as KN candidates.
 
@@ -244,9 +243,8 @@ def early_kn_candidates(
             *Measurement (band {}):*\n- Apparent magnitude: {:.2f} ± {:.2f}
             """.format(dict_filt[fid[i]], mag[i], err_mag[i])
         host_text = """
-            *Presumed host galaxy:*\n- Index in Mangrove catalog: {}\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
+            *Presumed host galaxy:*\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
             """.format(
-            pdf_mangrove.loc[host_galaxies[i], 'galaxy_idx'],
             pdf_mangrove.loc[host_galaxies[i], '2MASS_name'][2:-1],
             pdf_mangrove.loc[host_galaxies[i], 'lum_dist'],
             pdf_mangrove.loc[host_galaxies[i], 'dist_err'],

--- a/fink_filters/filter_early_kn_candidates/filter.py
+++ b/fink_filters/filter_early_kn_candidates/filter.py
@@ -243,8 +243,9 @@ def early_kn_candidates(
             *Measurement (band {}):*\n- Apparent magnitude: {:.2f} ± {:.2f}
             """.format(dict_filt[fid[i]], mag[i], err_mag[i])
         host_text = """
-            *Presumed host galaxy:*\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
+            *Presumed host galaxy:*\n- HyperlEDA Name: {:s}\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
             """.format(
+            pdf_mangrove.loc[host_galaxies[i], 'HyperlEDA_name'][2:-1],
             pdf_mangrove.loc[host_galaxies[i], '2MASS_name'][2:-1],
             pdf_mangrove.loc[host_galaxies[i], 'lum_dist'],
             pdf_mangrove.loc[host_galaxies[i], 'dist_err'],
@@ -307,7 +308,6 @@ def early_kn_candidates(
                         "type": "mrkdwn",
                         "text": tns_text
                     },
-                    
                 ]
             },
         ]

--- a/fink_filters/filter_early_kn_candidates/filter.py
+++ b/fink_filters/filter_early_kn_candidates/filter.py
@@ -243,9 +243,9 @@ def early_kn_candidates(
             *Measurement (band {}):*\n- Apparent magnitude: {:.2f} ± {:.2f}
             """.format(dict_filt[fid[i]], mag[i], err_mag[i])
         host_text = """
-            *Presumed host galaxy:*\n- HyperlEDA Name: {:s}\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
+            *Presumed host galaxy:*\n- HyperLEDA Name: {:s}\n- 2MASS XSC Name: {:s}\n- Luminosity distance: ({:.2f} ± {:.2f}) Mpc\n- RA/Dec: {:.7f} {:+.7f}\n- log10(Stellar mass/Ms): {:.2f}
             """.format(
-            pdf_mangrove.loc[host_galaxies[i], 'HyperlEDA_name'][2:-1],
+            pdf_mangrove.loc[host_galaxies[i], 'HyperLEDA_name'][2:-1],
             pdf_mangrove.loc[host_galaxies[i], '2MASS_name'][2:-1],
             pdf_mangrove.loc[host_galaxies[i], 'lum_dist'],
             pdf_mangrove.loc[host_galaxies[i], 'dist_err'],

--- a/fink_filters/filter_early_kn_candidates/filter_utils.py
+++ b/fink_filters/filter_early_kn_candidates/filter_utils.py
@@ -51,9 +51,8 @@ def make_mangrove_pdf(path_in, path_out='mangrove_filtered.csv',
         h5py.File(path_in, 'r')['__astropy_table__']
     ))
     pdf_mangrove = pdf_mangrove.loc[:, [
-        '2MASS_name',    # Name in the GWGC catalog
-        'idx',  # Integer between 0 and N where N is the total number galaxies
-                # in initial GLADE catalog used
+        'HyperLEDA_name',    # Name in the HyperLEDA catalog
+        '2MASS_name',    # Name in the 2MASS XSC catalog
         'RA',           # Right ascention [deg] of the GLADE galaxy
         'dec',          # Declination [deg] of the GLADE galaxy
         'dist',         # Luminosity distance [Mpc] of the GLADE galaxy,


### PR DESCRIPTION
We could let it when there is no name but I don't know if it's an efficient way of retrieving the information.

Reminder of the available names:
![image](https://user-images.githubusercontent.com/52038457/121859261-c809b580-ccf7-11eb-8053-48239086c6c2.png)
