### PR TITLE
Simple cuts implementation

### DIFF
--- a/fink_filters/filter_early_kn_candidates/filter.py
+++ b/fink_filters/filter_early_kn_candidates/filter.py
@@ -348,7 +348,7 @@ def early_kn_candidates(
                 os.environ['KNWEBHOOK_AMA_GALAXIES'],
                 json={
                     'blocks': blocks,
-                    'username': 'kilonova bot'
+                    'username': 'Cross-match-based kilonova bot'
                 },
                 headers={'Content-Type': 'application/json'},
             )

--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -282,7 +282,7 @@ def kn_candidates(
                 os.environ['KNWEBHOOK_AMA_CL'],
                 json={
                     'blocks': blocks,
-                    'username': 'kilonova bot'
+                    'username': 'Classifier-based kilonova bot'
                 },
                 headers={'Content-Type': 'application/json'},
             )

--- a/fink_filters/filter_kn_candidates/filter.py
+++ b/fink_filters/filter_kn_candidates/filter.py
@@ -83,7 +83,7 @@ def kn_candidates(
 
     high_drb = drb.astype(float) > 0.9
     high_classtar = classtar.astype(float) > 0.4
-    new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
+    new_detection = jd.astype(float) - jdstarthist.astype(float) < 14
     small_detection_history = ndethist.astype(float) < 20
     appeared = isdiffpos.astype(str) == 't'
     far_from_mpc = (ssdistnr.astype(float) > 10) | (ssdistnr.astype(float) < 0)
@@ -202,7 +202,7 @@ def kn_candidates(
                 rate[filt] = dmag / dt
         # filter messages on rate
         rate_all.append(rate[fid[i]])
-        if rate[fid[i]] < 0.3:
+        if rate[fid[i]] <= 0.3:
             continue
 
         # information to send

--- a/fink_filters/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/filter_rate_based_kn_candidates/filter.py
@@ -158,7 +158,6 @@ def rate_based_kn_candidates(
             continue
         delta_jd_last = jd_hist_allbands[-1] - jd_hist_allbands[-2]
 
-
         filt = fid[i]
         maskFilter = np.array(cfidc[f_kn].values[i]) == filt
         m = maskNotNone * maskFilter

--- a/fink_filters/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/filter_rate_based_kn_candidates/filter.py
@@ -203,7 +203,7 @@ def rate_based_kn_candidates(
             *New kilonova candidate:* <http://134.158.75.151:24000/{}|{}>
             """.format(alertID, alertID)
         score_text = """
-            *Other scores:*\n- Early SN Ia: {:.2f}\n- Ia SN vs non-Ia SN: {:.2f}\n- SN Ia and Core-Collapse vs non-SN: {:.2f}
+            *Scores:*\n- Early SN Ia: {:.2f}\n- Ia SN vs non-Ia SN: {:.2f}\n- SN Ia and Core-Collapse vs non-SN: {:.2f}
             """.format(rfscore[i], snn_snia_vs_nonia[i], snn_sn_vs_all[i])
         time_text = """
             *Time:*\n- {} UTC\n - Time since last detection: {:.1f} days\n - Time since first detection: {:.1f} days

--- a/fink_filters/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/filter_rate_based_kn_candidates/filter.py
@@ -152,11 +152,6 @@ def rate_based_kn_candidates(
         # Careful - Spark casts None as NaN!
         maskNotNone = ~np.isnan(np.array(cmagpsfc[f_kn].values[i]))
 
-        # Initialise containers
-        rate = {1: float('nan'), 2: float('nan')}
-        mag = {1: float('nan'), 2: float('nan')}
-        err_mag = {1: float('nan'), 2: float('nan')}
-
         # Time since last detection (independently of the band)
         jd_hist_allbands = np.array(np.array(cjdc[f_kn])[i])[maskNotNone]
         if len(jd_hist_allbands) < 2:
@@ -164,45 +159,44 @@ def rate_based_kn_candidates(
             continue
         delta_jd_last = jd_hist_allbands[-1] - jd_hist_allbands[-2]
 
-        # This could be further simplified as we only care
-        # about the filter of the last measurement.
-        # But the loop is fast enough to keep it for the moment
-        # (and it could be  useful later to have a
-        # general way to extract rates etc.)
-        for filt in [1, 2]:
-            maskFilter = np.array(cfidc[f_kn].values[i]) == filt
-            m = maskNotNone * maskFilter
-            if sum(m) < 2:
-                continue
-            # DC mag (history + last measurement)
-            mag_hist, err_hist = np.array([
-                dc_mag(k[0], k[1], k[2], k[3], k[4], k[5], k[6])
-                for k in zip(
-                    cfidc[f_kn].values[i][m][-2:],
-                    cmagpsfc[f_kn].values[i][m][-2:],
-                    csigmapsfc[f_kn].values[i][m][-2:],
-                    cmagnrc[f_kn].values[i][m][-2:],
-                    csigmagnrc[f_kn].values[i][m][-2:],
-                    cmagzpscic[f_kn].values[i][m][-2:],
-                    cisdiffposc[f_kn].values[i][m][-2:],
-                )
-            ]).T
 
-            # Grab the last measurement and its error estimate
-            mag[filt] = mag_hist[-1]
-            err_mag[filt] = err_hist[-1]
+        filt = fid[i]
+        maskFilter = np.array(cfidc[f_kn].values[i]) == filt
+        m = maskNotNone * maskFilter
+        if sum(m) < 2:
+            rate_all.append(0)
+            continue
+        # DC mag (history + last measurement)
+        mag_hist, err_hist = np.array([
+            dc_mag(k[0], k[1], k[2], k[3], k[4], k[5], k[6])
+            for k in zip(
+                cfidc[f_kn].values[i][m][-2:],
+                cmagpsfc[f_kn].values[i][m][-2:],
+                csigmapsfc[f_kn].values[i][m][-2:],
+                cmagnrc[f_kn].values[i][m][-2:],
+                csigmagnrc[f_kn].values[i][m][-2:],
+                cmagzpscic[f_kn].values[i][m][-2:],
+                cisdiffposc[f_kn].values[i][m][-2:],
+            )
+        ]).T
 
-            # Compute rate only if more than 1 measurement available
-            if len(mag_hist) > 1:
-                jd_hist = cjdc[f_kn].values[i][m]
+        # Grab the last measurement and its error estimate
+        mag = mag_hist[-1]
+        err_mag = err_hist[-1]
 
-                # rate is between `last` and `last-1` measurements only
-                dmag = mag_hist[-1] - mag_hist[-2]
-                dt = jd_hist[-1] - jd_hist[-2]
-                rate[filt] = dmag / dt
+        # Compute rate only if more than 1 measurement available
+        if len(mag_hist) > 1:
+            jd_hist = cjdc[f_kn].values[i][m]
+
+            # rate is between `last` and `last-1` measurements only
+            dmag = mag_hist[-1] - mag_hist[-2]
+            dt = jd_hist[-1] - jd_hist[-2]
+            rate = dmag / dt
+            error_rate = np.sqrt(err_hist[-1]**2 + err_hist[-2]**2) / dt
+
         # filter messages on rate
-        rate_all.append(rate[fid[i]])
-        if rate[fid[i]] <= 0.3:
+        rate_all.append(rate)
+        if rate <= 0.3:
             continue
 
         # information to send
@@ -217,8 +211,8 @@ def rate_based_kn_candidates(
             *Time:*\n- {} UTC\n - Time since last detection: {:.1f} days\n - Time since first detection: {:.1f} days
             """.format(Time(jd[i], format='jd').iso, delta_jd_last, delta_jd_first[i])
         measurements_text = """
-            *Measurement (band {}):*\n- Apparent magnitude: {:.2f} ± {:.2f} \n- Rate: {:.2f} mag/day\n
-            """.format(dict_filt[fid[i]], mag[fid[i]], err_mag[fid[i]], rate[fid[i]])
+            *Measurement (band {}):*\n- Apparent magnitude: {:.2f} ± {:.2f} \n- Rate: ({:.2f} ± {:.2f}) mag/day\n
+            """.format(dict_filt[fid[i]], mag, err_mag, rate, error_rate)
         radec_text = """
              *RA/Dec:*\n- [hours, deg]: {} {}\n- [deg, deg]: {:.7f} {:+.7f}
              """.format(ra_formatted[i], dec_formatted[i], ra[i], dec[i])
@@ -299,7 +293,7 @@ def rate_based_kn_candidates(
         # Monday is 1 and Sunday is 7
         is_friday = (now.isoweekday() == 5)
 
-        if (np.abs(b[i]) > 20) & (mag[fid[i]] < 20) & is_friday & ama_in_env:
+        if (np.abs(b[i]) > 20) & (mag < 20) & is_friday & ama_in_env:
             requests.post(
                 os.environ['KNWEBHOOK_AMA_CL'],
                 json={

--- a/fink_filters/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/filter_rate_based_kn_candidates/filter.py
@@ -41,6 +41,8 @@ def rate_based_kn_candidates(
     """
     Return alerts considered as KN candidates.
 
+    The cuts are based on Andreoni et al. 2021 https://arxiv.org/abs/2104.06352
+
     If the environment variable KNWEBHOOK is defined and match a webhook url,
     the alerts that pass the filter will be sent to the matching Slack channel.
 
@@ -278,7 +280,7 @@ def rate_based_kn_candidates(
                 log = logging.Logger('Kilonova filter')
                 log.warning(error_message.format(url_name))
 
-        ama_in_env = ('KNWEBHOOK_AMA_CL' in os.environ)
+        ama_in_env = ('KNWEBHOOK_AMA_RATE' in os.environ)
 
         # Send alerts to amateurs only on Friday
         now = datetime.datetime.utcnow()
@@ -291,7 +293,7 @@ def rate_based_kn_candidates(
                 os.environ['KNWEBHOOK_AMA_RATE'],
                 json={
                     'blocks': blocks,
-                    'username': 'kilonova bot'
+                    'username': 'Rate-based kilonova bot'
                 },
                 headers={'Content-Type': 'application/json'},
             )

--- a/fink_filters/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/filter_rate_based_kn_candidates/filter.py
@@ -32,10 +32,11 @@ from fink_science.conversion import dc_mag
 
 
 @pandas_udf(BooleanType(), PandasUDFType.SCALAR)
-def kn_candidates(
+def rate_based_kn_candidates(
         objectId, knscore, rfscore, snn_snia_vs_nonia, snn_sn_vs_all, drb,
-        classtar, jdstarthist, ndethist, cdsxmatch, ra, dec, cjdc, cfidc,
-        cmagpsfc, csigmapsfc, cmagnrc, csigmagnrc, cmagzpscic, cisdiffposc
+        classtar, jdstarthist, ndethist, cdsxmatch, ra, dec, ssdistnr, cjdc,
+        cfidc, cmagpsfc, csigmapsfc, cmagnrc, csigmagnrc, cmagzpscic,
+        cisdiffposc
         ) -> pd.Series:
     """
     Return alerts considered as KN candidates.
@@ -64,6 +65,8 @@ def kn_candidates(
         Column containing the right Ascension of candidate; J2000 [deg]
     dec: Spark DataFrame Column
         Column containing the declination of candidate; J2000 [deg]
+    ssdistnr: Spark DataFrame Column
+        distance to nearest known solar system object; -999.0 if none [arcsec]
     cjdc, cfidc, cmagpsfc, csigmapsfc, cmagnrc, csigmagnrc, cmagzpscic: Spark DataFrame Columns
         Columns containing history of fid, magpsf, sigmapsf, magnr, sigmagnr,
         magzpsci, isdiffpos as arrays
@@ -76,12 +79,14 @@ def kn_candidates(
     # Extract last (new) measurement from the concatenated column
     jd = cjdc.apply(lambda x: x[-1])
     fid = cfidc.apply(lambda x: x[-1])
+    isdiffpos = cisdiffposc.apply(lambda x: x[-1])
 
-    high_knscore = knscore.astype(float) > 0.5
-    high_drb = drb.astype(float) > 0.5
+    high_drb = drb.astype(float) > 0.9
     high_classtar = classtar.astype(float) > 0.4
-    new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
+    new_detection = jd.astype(float) - jdstarthist.astype(float) < 14
     small_detection_history = ndethist.astype(float) < 20
+    appeared = isdiffpos.astype(str) == 't'
+    far_from_mpc = (ssdistnr.astype(float) > 10) | (ssdistnr.astype(float) < 0)
 
     list_simbad_galaxies = [
         "galaxy",
@@ -105,8 +110,8 @@ def kn_candidates(
     keep_cds = \
         ["Unknown", "Transient", "Fail"] + list_simbad_galaxies
 
-    f_kn = high_knscore & high_drb & high_classtar & new_detection
-    f_kn = f_kn & small_detection_history & cdsxmatch.isin(keep_cds)
+    f_kn = high_drb & high_classtar & new_detection & small_detection_history
+    f_kn = f_kn & cdsxmatch.isin(keep_cds) & appeared & far_from_mpc
 
     if f_kn.any():
         # Galactic latitude transformation
@@ -142,6 +147,7 @@ def kn_candidates(
         jd = np.array(jd)[f_kn]
 
     dict_filt = {1: 'g', 2: 'r'}
+    rate_all = []
     for i, alertID in enumerate(objectId[f_kn]):
         # Careful - Spark casts None as NaN!
         maskNotNone = ~np.isnan(np.array(cmagpsfc[f_kn].values[i]))
@@ -153,6 +159,9 @@ def kn_candidates(
 
         # Time since last detection (independently of the band)
         jd_hist_allbands = np.array(np.array(cjdc[f_kn])[i])[maskNotNone]
+        if len(jd_hist_allbands) < 2:
+            rate_all.append(0)
+            continue
         delta_jd_last = jd_hist_allbands[-1] - jd_hist_allbands[-2]
 
         # This could be further simplified as we only care
@@ -163,18 +172,19 @@ def kn_candidates(
         for filt in [1, 2]:
             maskFilter = np.array(cfidc[f_kn].values[i]) == filt
             m = maskNotNone * maskFilter
-
+            if sum(m) < 2:
+                continue
             # DC mag (history + last measurement)
             mag_hist, err_hist = np.array([
                 dc_mag(k[0], k[1], k[2], k[3], k[4], k[5], k[6])
                 for k in zip(
-                    cfidc[f_kn].values[i][m],
-                    cmagpsfc[f_kn].values[i][m],
-                    csigmapsfc[f_kn].values[i][m],
-                    cmagnrc[f_kn].values[i][m],
-                    csigmagnrc[f_kn].values[i][m],
-                    cmagzpscic[f_kn].values[i][m],
-                    cisdiffposc[f_kn].values[i][m]
+                    cfidc[f_kn].values[i][m][-2:],
+                    cmagpsfc[f_kn].values[i][m][-2:],
+                    csigmapsfc[f_kn].values[i][m][-2:],
+                    cmagnrc[f_kn].values[i][m][-2:],
+                    csigmagnrc[f_kn].values[i][m][-2:],
+                    cmagzpscic[f_kn].values[i][m][-2:],
+                    cisdiffposc[f_kn].values[i][m][-2:],
                 )
             ]).T
 
@@ -190,6 +200,10 @@ def kn_candidates(
                 dmag = mag_hist[-1] - mag_hist[-2]
                 dt = jd_hist[-1] - jd_hist[-2]
                 rate[filt] = dmag / dt
+        # filter messages on rate
+        rate_all.append(rate[fid[i]])
+        if rate[fid[i]] <= 0.3:
+            continue
 
         # information to send
         alert_text = """
@@ -297,5 +311,7 @@ def kn_candidates(
         else:
             log = logging.Logger('Kilonova filter')
             log.warning(error_message.format(url_name))
+
+    f_kn.loc[f_kn] = np.array(rate_all) > 0.3
 
     return f_kn


### PR DESCRIPTION
Changes:
- no threshold on knscore
- `drb > 0.9` instead of 0.5
- time: max 14 days in total,
- object appeared (`isdiffpos == t`)
- distance to mpc > 10''
- rate > 0.3

This results in 34 candidates in April from 24 objects including 3 SNIa.
1146 candidates in 20 months (before 18 june 2021) so ~ 60 candidates/month. From 1057 objects => usually 1 alert/object, could be change by computing the maximum rate instead of the last rate. Mostly unknown.

36 candidates pass the cuts of both 2PC and rate in 18-20 months

To consider:
- time: max 14 days in total, 10 days for band g, 12 days for band r
- We might want to replace the computation of the rate by a linear fit, and only consider objects if the points in the band are at least 0.5 day apart.
- check if there are other alerts with other ID in 3'' (distnr), could provoke ghost. Problem: we don't know the nature of the object, we might reject galaxies. `distnr < 1 | distnr > 3` actually leaves most alerts (1024/1146)
- sgscore1 < 0.5: no stellar counterpart. It would not leave a lot of objects and relies on SExtractor, so I would not trust this one. Leaves 213 alerts
Adding thresholds on sgscore and distnr leaves 144/1146 alerts.