### PR TITLE
Adding ZTF DR OID to notifications

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -111,8 +111,8 @@ def anomaly_notification_(
         oid = filter_utils.get_OID(row.ra, row.dec)
         t1a = f'ID: [{row.objectId}](https://fink-portal.org/{row.objectId})'
         t1b = f'ID: <https://fink-portal.org/{row.objectId}|{row.objectId}>'
-        t_oid_1a = f'ZTF DR OID: [{oid}](https://ztf.snad.space/view/{oid})'
-        t_oid_1b = f'ZTF DR OID: <https://ztf.snad.space/view/{oid}|{oid}>'
+        t_oid_1a = f'DR OID (<1''): [{oid}](https://ztf.snad.space/view/{oid})'
+        t_oid_1b = f'DR OID (<1''): <https://ztf.snad.space/view/{oid}|{oid}>'
         t2_ = f'GAL coordinates: {round(gal.l.deg, 6)},   {round(gal.b.deg, 6)}'
         t3_ = f'UTC: {str(row.timestamp)[:-3]}'
         t4_ = f'Real bogus: {round(row.rb, 2)}'

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -108,18 +108,23 @@ def anomaly_notification_(
     tg_data, slack_data = [], []
     for _, row in pdf_anomalies.iterrows():
         gal = SkyCoord(ra=row.ra * u.degree, dec=row.dec * u.degree, frame='icrs').galactic
+        oid = filter_utils.get_OID(row.ra, row.dec)
         t1a = f'ID: [{row.objectId}](https://fink-portal.org/{row.objectId})'
         t1b = f'ID: <https://fink-portal.org/{row.objectId}|{row.objectId}>'
+        t_oid_1a = f'ZTF DR OID: [{oid}](https://ztf.snad.space/view/{oid})'
+        t_oid_1b = f'ZTF DR OID: <https://ztf.snad.space/view/{oid}|{oid}>'
         t2_ = f'GAL coordinates: {round(gal.l.deg, 6)},   {round(gal.b.deg, 6)}'
         t3_ = f'UTC: {str(row.timestamp)[:-3]}'
         t4_ = f'Real bogus: {round(row.rb, 2)}'
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
         tg_data.append(f'''{t1a}
+{t_oid_1a}
 {t2_}
 {t3_}
 {t4_}
 {t5_}''')
         slack_data.append(f'''{t1b}
+{t_oid_1b}
 {t2_}
 {t3_}
 {t4_}

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -111,8 +111,8 @@ def anomaly_notification_(
         oid = filter_utils.get_OID(row.ra, row.dec)
         t1a = f'ID: [{row.objectId}](https://fink-portal.org/{row.objectId})'
         t1b = f'ID: <https://fink-portal.org/{row.objectId}|{row.objectId}>'
-        t_oid_1a = f'DR OID (<1''): [{oid}](https://ztf.snad.space/view/{oid})'
-        t_oid_1b = f'DR OID (<1''): <https://ztf.snad.space/view/{oid}|{oid}>'
+        t_oid_1a = f'DR OID (<1"): [{oid}](https://ztf.snad.space/view/{oid})'
+        t_oid_1b = f'DR OID (<1"): <https://ztf.snad.space/view/{oid}|{oid}>'
         t2_ = f'GAL coordinates: {round(gal.l.deg, 6)},   {round(gal.b.deg, 6)}'
         t3_ = f'UTC: {str(row.timestamp)[:-3]}'
         t4_ = f'Real bogus: {round(row.rb, 2)}'

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -121,12 +121,13 @@ def get_OID(ra, dec):
           or
             None, if nothing was found
     '''
-    url = "https://api.telegram.org/bot"
-    url += os.environ['ANOMALY_TG_TOKEN']
-    method = url + "/sendMessage"
     r = requests.get(
-        url=f'http://db.ztf.snad.space/api/v3/data/latest/circle/full/json?ra={ra}&dec={dec}&radius_arcsec=1')
+        url=f'http://db.ztf.snad.space/api/v3/data/latest/circle/full/json?ra={ra}&dec={dec}&radius_arcsec=1'
+    )
     if r.status_code != 200:
+        url = "https://api.telegram.org/bot"
+        url += os.environ['ANOMALY_TG_TOKEN']
+        method = url + "/sendMessage"
         requests.post(method, data={
             "chat_id": "@fink_test",
             "text": str(r.status_code)

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -99,3 +99,38 @@ def msg_handler_tg(tg_data, channel_id, med):
                 timeout=8
             )
         time.sleep(3)
+
+
+def get_OID(ra, dec):
+    '''
+    Notes
+    ----------
+    The function determines the nearest ZTF DR OID by the given ra and dec.
+
+    Parameters
+    ----------
+    dec: float
+        Declination of candidate; J2000 [deg]
+    ra: string
+        Right Ascension of candidate; J2000 [deg]
+
+    Returns
+    -------
+        out: str
+            ZTF DR OID
+    '''
+    url = "https://api.telegram.org/bot"
+    url += os.environ['ANOMALY_TG_TOKEN']
+    method = url + "/sendMessage"
+    r = requests.get(
+        url=f'http://db.ztf.snad.space/api/v3/data/latest/circle/full/json?ra={ra}&dec={dec}&radius_arcsec=1')
+    if r.status_code != 200:
+        requests.post(method, data={
+            "chat_id": "@fink_test",
+            "text": str(r.status_code)
+        }, timeout=8)
+        return None
+    oids = [key for key, _ in r.json().items()]
+    if oids:
+        return oids[0]
+    return None

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -118,6 +118,8 @@ def get_OID(ra, dec):
     -------
         out: str
             ZTF DR OID
+          or 
+            None, if nothing was found
     '''
     url = "https://api.telegram.org/bot"
     url += os.environ['ANOMALY_TG_TOKEN']

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -118,7 +118,7 @@ def get_OID(ra, dec):
     -------
         out: str
             ZTF DR OID
-          or 
+          or
             None, if nothing was found
     '''
     url = "https://api.telegram.org/bot"

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -111,7 +111,7 @@ def get_OID(ra, dec):
     ----------
     dec: float
         Declination of candidate; J2000 [deg]
-    ra: string
+    ra: float
         Right Ascension of candidate; J2000 [deg]
 
     Returns


### PR DESCRIPTION
Hi!
There was a need to add a link to [ztf.snad.space](http://ztf.snad.space/) to notifications. For this purpose I wrote the following simple function:
```
def get_OID(ra, dec):
    '''
    Notes
    ----------
    The function determines the nearest ZTF DR OID by the given ra and dec.
    Parameters
    ----------
    dec: float
        Declination of candidate; J2000 [deg]
    ra: float
        Right Ascension of candidate; J2000 [deg]
    Returns
    -------
        out: str
            ZTF DR OID
          or
            None, if nothing was found
    '''
    url = "https://api.telegram.org/bot"
    url += os.environ['ANOMALY_TG_TOKEN']
    method = url + "/sendMessage"
    r = requests.get(
        url=f'http://db.ztf.snad.space/api/v3/data/latest/circle/full/json?ra={ra}&dec={dec}&radius_arcsec=1')
    if r.status_code != 200:
        requests.post(method, data={
            "chat_id": "@fink_test",
            "text": str(r.status_code)
        }, timeout=8)
        return None
    oids = [key for key, _ in r.json().items()]
    if oids:
        return oids[0]
    return None
```

This function simply queries the server for the first J2000 coordinate match.