### PR TITLE
Use the channel ID instead of the test channel

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -131,6 +131,8 @@ def anomaly_notification_(
         t4_ = f'Real bogus: {round(row.rb, 2)}'
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
         cutout, curve, cutout_perml, curve_perml = filter_utils.get_data_permalink_slack(row.objectId)
+        curve.seek(0)
+        cutout.seek(0)
         cutout_perml = f"<{cutout_perml}|{' '}>"
         curve_perml = f"<{curve_perml}|{' '}>"
         tg_data.append((f'''{t1a}

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -208,7 +208,7 @@ def msg_handler_tg(tg_data, channel_id, med):
         res = requests.post(
             method,
             params={
-                "chat_id": "@fink_test",
+                "chat_id": channel_id,
                 "media": f'''[
                     {{
                         "type" : "photo",

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -26,7 +26,6 @@ from slack_sdk.errors import SlackApiError
 
 import io
 
-
 def get_data_permalink_slack(ztf_id):
     '''
 
@@ -68,11 +67,8 @@ def get_data_permalink_slack(ztf_id):
             ]
         )
         time.sleep(3)
-        curve.seek(0)
-        cutout.seek(0)
     except SlackApiError as e:
         if e.response["ok"] is False:
-            print(e.response['error'])
             requests.post(
                 "https://api.telegram.org/bot" + os.environ['ANOMALY_TG_TOKEN'] + "/sendMessage",
                 data={


### PR DESCRIPTION
Bug fix for release 3.16 (anomaly detection filter)
- [x] grant correct permission (files:write) for the slack bot
- [x] understand failure for telegram when sending files