### PR TITLE
Telegram API Error 429

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -131,6 +131,8 @@ def anomaly_notification_(
         t4_ = f'Real bogus: {round(row.rb, 2)}'
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
         cutout, curve, cutout_perml, curve_perml = filter_utils.get_data_permalink_slack(row.objectId)
+        curve.seek(0)
+        cutout.seek(0)
         cutout_perml = f"<{cutout_perml}|{' '}>"
         curve_perml = f"<{curve_perml}|{' '}>"
         tg_data.append((f'''{t1a}

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -208,7 +208,7 @@ def msg_handler_tg(tg_data, channel_id, med):
         res = requests.post(
             method,
             params={
-                "chat_id": "@fink_test",
+                "chat_id": channel_id,
                 "media": f'''[
                     {{
                         "type" : "photo",

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -26,7 +26,6 @@ from slack_sdk.errors import SlackApiError
 
 import io
 
-
 def get_data_permalink_slack(ztf_id):
     '''
 
@@ -68,11 +67,8 @@ def get_data_permalink_slack(ztf_id):
             ]
         )
         time.sleep(3)
-        curve.seek(0)
-        cutout.seek(0)
     except SlackApiError as e:
         if e.response["ok"] is False:
-            print(e.response['error'])
             requests.post(
                 "https://api.telegram.org/bot" + os.environ['ANOMALY_TG_TOKEN'] + "/sendMessage",
                 data={

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -199,7 +199,7 @@ def msg_handler_tg(tg_data, channel_id, med):
         timeout=25
     )
     status_check(res)
-    time.sleep(8)
+    time.sleep(10)
     for text_data, cutout, curve in tg_data:
         res = requests.post(
             method,
@@ -225,7 +225,7 @@ def msg_handler_tg(tg_data, channel_id, med):
             timeout=25
         )
         status_check(res)
-        time.sleep(8)
+        time.sleep(10)
 
 
 def get_OID(ra, dec):


### PR DESCRIPTION
The [Telegram API documentation](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this)  regarding restrictions on sending messages to groups says the following: 

> Also note that your bot will not be able to send more than 20 messages per minute to the same group

A message with two attached images is considered by Telegram API as two messages, so no more than 14 messages should be sent per minute with a delay of 8 seconds, so I don't understand what causes error 429.

I suggest to try increasing the delay to 10 seconds -- if that doesn't help, I'll look for another reason. With such a delay, even if Telegram API considers one message as 3 (text + two pictures), no more than 20 messages will be sent per minute.