### PR TITLE
Anomaly notifications only from specified area

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -26,7 +26,7 @@ def anomaly_notification_(
         df_proc, threshold=10,
         send_to_tg=False, channel_id=None,
         send_to_slack=False, channel_name=None,
-        trick_par=10):
+        trick_par=10, cut_coords=False):
     """ Create event notifications with a high `anomaly_score` value
 
     Notes
@@ -58,6 +58,11 @@ def anomaly_notification_(
     trick_par: int, optional
         Internal buffer to reduce the number of candidates while giving
         space to reach the `threshold`. Defaut is 10.
+    cut_coords: bool
+        If this is True, only objects from the area bounded
+        by the following coordinates are considered:
+            1) delta <= 20°
+            2) alpha ∈ (0°, 60°)⋃(340°, 360°)
 
     Returns
     ----------
@@ -108,11 +113,17 @@ def anomaly_notification_(
     ['ZTF21acoshvy' 'ZTF18aapgymv' 'ZTF19aboujyi' 'ZTF18abgjtxx' 'ZTF18aaypnnd'
      'ZTF18abbtxsx' 'ZTF18aaakhsv' 'ZTF18actxdmj' 'ZTF18aapoack' 'ZTF18abzvnya']
     """
+    # Filtering by coordinates
+    if cut_coords:
+        df_proc = df_proc.filter('dec <= 20 AND (ra <= 60 OR ra >= 340)')
+        # We need to know the total number of objects per night which satisfy the condition on coordinates
+        cut_count = df_proc.count()
     # Compute the median for the night
     med = df_proc.select('anomaly_score').approxQuantile('anomaly_score', [0.5], 0.05)
     med = round(med[0], 2)
 
     # Extract anomalous objects
+
     pdf_anomalies_ext = df_proc.sort(['anomaly_score'], ascending=True).limit(trick_par * threshold).toPandas()
     pdf_anomalies_ext = pdf_anomalies_ext.drop_duplicates(['objectId'])
     upper_bound = np.max(pdf_anomalies_ext['anomaly_score'].values[:threshold])
@@ -127,6 +138,10 @@ def anomaly_notification_(
         t_oid_1a = f"DR OID (<1''): [{oid}](https://ztf.snad.space/view/{oid})"
         t_oid_1b = f"DR OID (<1''): <https://ztf.snad.space/view/{oid}|{oid}>"
         t2_ = f'GAL coordinates: {round(gal.l.deg, 6)},   {round(gal.b.deg, 6)}'
+        t_ = f'''
+EQU: {row.ra},   {row.dec}'''
+        if cut_coords:
+            t2_ += t_
         t3_ = f'UTC: {str(row.timestamp)[:-3]}'
         t4_ = f'Real bogus: {round(row.rb, 2)}'
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
@@ -149,11 +164,19 @@ def anomaly_notification_(
 {t4_}
 {t5_}
 {cutout_perml}{curve_perml}''')
+    init_msg = f'Median anomaly score overnight: {med}.'
+    if cut_coords:
+        init_msg += f'''
+(of the objects in the sky area)
+Sky area:
+    1) delta <= 20°
+    2) alpha ∈ (0°, 60°)⋃(340°, 360°)
+Total number of objects per night in the area: {cut_count}.
+'''
     if send_to_slack:
-        filter_utils.msg_handler_slack(slack_data, channel_name, med)
+        filter_utils.msg_handler_slack(slack_data, channel_name, init_msg)
     if send_to_tg:
-        filter_utils.msg_handler_tg(tg_data, channel_id, med)
-
+        filter_utils.msg_handler_tg(tg_data, channel_id, init_msg)
     return pdf_anomalies
 
 

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -24,6 +24,7 @@ import matplotlib.pyplot as plt
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+
 import io
 
 def get_data_permalink_slack(ztf_id):
@@ -112,7 +113,7 @@ def status_check(res):
         return False
     return True
 
-def msg_handler_slack(slack_data, channel_name, med):
+def msg_handler_slack(slack_data, channel_name, init_msg):
     '''
     Notes
     ----------
@@ -124,15 +125,15 @@ def msg_handler_slack(slack_data, channel_name, med):
         List of lines. Each item is a separate notification
     channel_name: string
         Channel name in Slack
-    med: float
-        Median anomaly score overnight
+    init_msg: str
+        Initial message
 
     Returns
     -------
         None
     '''
     slack_client = WebClient(os.environ['ANOMALY_SLACK_TOKEN'])
-    slack_data = [f'Median anomaly score overnight: {med}'] + slack_data
+    slack_data = [init_msg] + slack_data
     try:
         for slack_obj in slack_data:
             slack_client.chat_postMessage(
@@ -160,7 +161,7 @@ def msg_handler_slack(slack_data, channel_name, med):
                 timeout=25
             )
 
-def msg_handler_tg(tg_data, channel_id, med):
+def msg_handler_tg(tg_data, channel_id, init_msg):
     '''
     Notes
     ----------
@@ -179,8 +180,8 @@ def msg_handler_tg(tg_data, channel_id, med):
                 light curve picture
     channel_id: string
         Channel id in Telegram
-    med: float
-        Median anomaly score overnight
+    init_msg: str
+        Initial message
 
     Returns
     -------
@@ -193,7 +194,7 @@ def msg_handler_tg(tg_data, channel_id, med):
         url + '/sendMessage',
         data={
             "chat_id": channel_id,
-            "text": f'Median anomaly score overnight: {med}',
+            "text": init_msg,
             "parse_mode": "markdown"
         },
         timeout=25
@@ -302,7 +303,8 @@ def get_curve(ztf_id):
             'withupperlim': 'True'
         }
     )
-    status_check(r)
+    if not status_check(r):
+        return None
 
     # Format output in a DataFrame
     pdf = pd.read_json(io.BytesIO(r.content))


### PR DESCRIPTION
These changes add a new parameter `cut_coords` to the definition of the `anomaly_notification_` function. If `cut_coords==True`, only those objects whose coordinates satisfy the following criteria are considered:
```
1) delta <= 20°
2) alpha ∈ (0°, 60°)⋃(340°, 360°)
```

The function is expected to be called separately as follows: 
```Python
anomaly_notification_(df_proc, threshold=5,
        send_to_tg=True, channel_id='@anomaly_spec',
        send_to_slack=False, channel_name=None,
        trick_par=10, cut_coords=True)
```

This way, these notifications will only be uploaded to a separate new channel in Telegram https://t.me/anomaly_spec.