### PR TITLE
Adding the number of previous references to the object

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -153,7 +153,7 @@ EQU: {row.ra},   {row.dec}'''
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
         if row.objectId in history_objects:
             t5_ += f'''
-Detected as top-{threshold} in the last {history_period} days: {history_objects[row.objectId]} times.'''
+Detected as top-{threshold} in the last {history_period} days: {history_objects[row.objectId]} {'times' if history_objects[row.objectId] > 1 else 'time'}.'''
         cutout, curve, cutout_perml, curve_perml = filter_utils.get_data_permalink_slack(row.objectId)
         curve.seek(0)
         cutout.seek(0)

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -66,8 +66,8 @@ def anomaly_notification_(
             1) delta <= 20°
             2) alpha ∈ (0°, 60°)⋃(340°, 360°)
     history_period: int
-            Time period in days number of references of 
-            objects for which the number of references is calculated
+            Time period in days for which the number
+            of references is calculated
 
     Returns
     ----------

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -150,7 +150,7 @@ EQU: {row.ra},   {row.dec}'''
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
         if row.objectId in history_objects:
             t5_ += f'''
-Detected as top-{threshold} anomaly in the last {history_period} days: {history_objects[row.objectId]} times.'''
+Detected as top-{threshold} in the last {history_period} days: {history_objects[row.objectId]} times.'''
         cutout, curve, cutout_perml, curve_perml = filter_utils.get_data_permalink_slack(row.objectId)
         curve.seek(0)
         cutout.seek(0)

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -65,6 +65,9 @@ def anomaly_notification_(
         by the following coordinates are considered:
             1) delta <= 20°
             2) alpha ∈ (0°, 60°)⋃(340°, 360°)
+    history_period: int
+            Time period in days number of references of 
+            objects for which the number of references is calculated
 
     Returns
     ----------

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+
 
 from fink_filters.filter_anomaly_notification import filter_utils
 
@@ -26,7 +28,7 @@ def anomaly_notification_(
         df_proc, threshold=10,
         send_to_tg=False, channel_id=None,
         send_to_slack=False, channel_name=None,
-        trick_par=10, cut_coords=False):
+        trick_par=10, cut_coords=False, history_period=90):
     """ Create event notifications with a high `anomaly_score` value
 
     Notes
@@ -129,6 +131,8 @@ def anomaly_notification_(
     upper_bound = np.max(pdf_anomalies_ext['anomaly_score'].values[:threshold])
     pdf_anomalies = pdf_anomalies_ext[pdf_anomalies_ext['anomaly_score'] <= upper_bound]
 
+    history_objects = filter_utils.get_an_history(history_period)
+
     tg_data, slack_data = [], []
     for _, row in pdf_anomalies.iterrows():
         gal = SkyCoord(ra=row.ra * u.degree, dec=row.dec * u.degree, frame='icrs').galactic
@@ -144,6 +148,9 @@ EQU: {row.ra},   {row.dec}'''
         t3_ = f'UTC: {str(row.timestamp)[:-3]}'
         t4_ = f'Real bogus: {round(row.rb, 2)}'
         t5_ = f'Anomaly score: {round(row.anomaly_score, 2)}'
+        if row.objectId in history_objects:
+            t5_ += f'''
+Detected as top-{threshold} anomaly in the last {history_period} days: {history_objects[row.objectId]} times.'''
         cutout, curve, cutout_perml, curve_perml = filter_utils.get_data_permalink_slack(row.objectId)
         curve.seek(0)
         cutout.seek(0)


### PR DESCRIPTION
This small update adds the number of object mentions for the previous _history_period_ days to the notification text.
![image](https://github.com/astrolabsoftware/fink-filters/assets/93309519/a91b17bd-7848-4457-953e-71135afac57c)

