### PR TITLE
Added the newly discovered pTDE candidate to the list of followed TDEs

### DIFF
--- a/fink_filters/filter_known_tde/data/TDElist_Gezari2021.tsv
+++ b/fink_filters/filter_known_tde/data/TDElist_Gezari2021.tsv
@@ -54,3 +54,4 @@ AT2019lwu/ZTF19abidbya	ZTF	O	0.117	43.60	4.14	van Velzen et al. 2021
 AT2019meg/ZTF19abhhjcc	ZTF	O	0.152	44.36	4.44	van Velzen et al. 2021
 AT2019mha/ATLAS19qqu	ATLAS	O	0.148	44.05	4.35	van Velzen et al. 2021
 AT2019qiz/ZTF19abzrhgq	ZTF	O	0.0151	43.44	4.27	van Velzen et al. 2021
+ZTF19abuwgfg ZTF O NaN NaN NaN Fink collaboration


### PR DESCRIPTION
I added the newly discovered pTDE candidate (ZTF19abuwgfg) to the list of followed TDEs from Gezari 2021. This way, we will get notified when it's active again, to perform follow-up study.
