### PR TITLE
Change endpoint for downloading cutouts for anomaly

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -428,8 +428,8 @@ def get_cutout(ztf_id):
     '''
     # transfer cutout data
     r = requests.post(
-        "https://fink-portal.org/api/v1/ctouts",
-        json={"objectId": ztf_id, "kind": "Science"},
+        "https://fink-portal.org/api/v1/cutouts",
+        json={"objectId": ztf_id, "kind": "Science", "output-format": "array"},
     )
     if not status_check(r, 'get cutouts'):
         return io.BytesIO()

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -433,7 +433,7 @@ def get_cutout(ztf_id):
     )
     if not status_check(r, 'get cutouts'):
         return io.BytesIO()
-    data = np.log(np.array(r.json()[0]['b:cutoutScience_stampData'], dtype=float))
+    data = np.log(np.array(r.json()['b:cutoutScience_stampData'], dtype=float))
     plt.axis('off')
     plt.imshow(data, cmap='PuBu_r')
     buf = io.BytesIO()

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -428,8 +428,8 @@ def get_cutout(ztf_id):
     '''
     # transfer cutout data
     r = requests.post(
-        "https://fink-portal.org/api/v1/objects",
-        json={"objectId": ztf_id, "withcutouts": "True", "cols": "b:cutoutScience_stampData"},
+        "https://fink-portal.org/api/v1/ctouts",
+        json={"objectId": ztf_id, "kind": "Science"},
     )
     if not status_check(r, 'get cutouts'):
         return io.BytesIO()


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #211 

## What changes were proposed in this pull request?

Use the endpoint `/cutouts` rather than `/objects` to download the last cutout.

## How was this patch tested?

CI
