### PR TITLE
add username to debug

### DIFF
--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -89,7 +89,6 @@ def anomaly_notification_(
     >>> from fink_utils.spark.utils import concat_col
     >>> from fink_science.ad_features.processor import extract_features_ad
     >>> from fink_science.anomaly_detection.processor import anomaly_score
-    >>> from fink_science.anomaly_detection.processor import ANOMALY_MODELS
 
     >>> df = spark.read.format('parquet').load('datatest/regular')
     >>> MODELS = ['_beta', ''] # '' corresponds to the model for a telegram channel

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -89,9 +89,10 @@ def anomaly_notification_(
     >>> from fink_utils.spark.utils import concat_col
     >>> from fink_science.ad_features.processor import extract_features_ad
     >>> from fink_science.anomaly_detection.processor import anomaly_score
+    >>> from fink_science.anomaly_detection.processor import ANOMALY_MODELS
 
     >>> df = spark.read.format('parquet').load('datatest/regular')
-    >>> MODELS = ['_beta', ''] # '' corresponds to the model for a telegram channel
+    >>> MODELS = ANOMALY_MODELS # ['_beta', ''] # '' corresponds to the model for a telegram channel
     >>> what = [
     ...     'jd', 'fid', 'magpsf', 'sigmapsf',
     ...     'magnr', 'sigmagnr', 'isdiffpos', 'distnr']

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -92,7 +92,7 @@ def anomaly_notification_(
     >>> from fink_science.anomaly_detection.processor import ANOMALY_MODELS
 
     >>> df = spark.read.format('parquet').load('datatest/regular')
-    >>> MODELS = ANOMALY_MODELS # ['_beta', ''] # '' corresponds to the model for a telegram channel
+    >>> MODELS = [''] + ANOMALY_MODELS # ['_beta', ''] # '' corresponds to the model for a telegram channel
     >>> what = [
     ...     'jd', 'fid', 'magpsf', 'sigmapsf',
     ...     'magnr', 'sigmagnr', 'isdiffpos', 'distnr']

--- a/fink_filters/filter_anomaly_notification/filter.py
+++ b/fink_filters/filter_anomaly_notification/filter.py
@@ -92,7 +92,7 @@ def anomaly_notification_(
     >>> from fink_science.anomaly_detection.processor import ANOMALY_MODELS
 
     >>> df = spark.read.format('parquet').load('datatest/regular')
-    >>> MODELS = [''] + ANOMALY_MODELS # ['_beta', ''] # '' corresponds to the model for a telegram channel
+    >>> MODELS = ['_beta', ''] # '' corresponds to the model for a telegram channel
     >>> what = [
     ...     'jd', 'fid', 'magpsf', 'sigmapsf',
     ...     'magnr', 'sigmagnr', 'isdiffpos', 'distnr']

--- a/fink_filters/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/filter_anomaly_notification/filter_utils.py
@@ -296,7 +296,7 @@ def load_to_anomaly_base(data, model):
         'username': username,
         'password': os.environ['ANOMALY_TG_TOKEN']
     })
-    if status_check(res, 'load_to_anomaly_base_login'):
+    if status_check(res, f'load_to_anomaly_base_login_{username}'):
         access_token = json.loads(res.text)['access_token']
         tg_id_data = requests.get(url=f'https://anomaly.fink-broker.org:443/user/get_tgid/{username}')
         if status_check(tg_id_data, 'tg_id loading'):


### PR DESCRIPTION
We have a little problem: for some reason, it is not possible to login to all accounts except `beta` in [this line](https://github.com/astrolabsoftware/fink-filters/blob/master/fink_filters/filter_anomaly_notification/filter_utils.py#L295). I suspect that for some reason the wrong usernames are being passed to `username`, but I can't figure out the reason yet. I want to add the contents of `username` to the error messages