### PR TITLE
Enable different tokens for Slack

### DIFF
--- a/fink_filters/ztf/filter_anomaly_notification/filter.py
+++ b/fink_filters/ztf/filter_anomaly_notification/filter.py
@@ -205,7 +205,9 @@ def anomaly_notification_(
         t5_ += f"""
 Detected as top-{threshold} in the last {history_period} days: {history_objects[row.objectId] + 1} {"times" if (history_objects[row.objectId] + 1) > 1 else "time"}."""
         cutout, curve, cutout_perml, curve_perml = (
-            filter_utils.get_data_permalink_slack(row.objectId, curve_last_days)
+            filter_utils.get_data_permalink_slack(
+                ztf_id=row.objectId, last_days=curve_last_days
+            )
         )
         curve.seek(0)
         cutout.seek(0)

--- a/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
@@ -190,9 +190,9 @@ def get_an_history(delta_date=90):
 
 def get_data_permalink_slack(
     ztf_id,
+    last_days=None,
     slack_token_env="ANOMALY_SLACK_TOKEN",
     tg_token_env="ANOMALY_TG_TOKEN",
-    last_days=None,
 ):
     """Loads cutout and light curve via the Fink API and copies them to the Slack server
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #269 

## What changes were proposed in this pull request?

Enable passing different Slack bot token. TG functionalities remains untouched. Long term: we should move this code out from fink-filters.

## How was this patch tested?

CI