### PR TITLE
[Rubin] Fixing negative min flux in early SN Ia filter

### DIFF
--- a/fink_filters/rubin/livestream/filter_early_snia_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_early_snia_candidate/filter.py
@@ -48,9 +48,7 @@ def early_snia_candidate(
     """
     # calculate log flux ratio
     f_min = min(10, abs(fu.extract_min_flux(diaObject)))
-    flux_ratio = np.log10(
-        fu.extract_max_flux(diaObject) / f_min
-    )
+    flux_ratio = np.log10(fu.extract_max_flux(diaObject) / f_min)
 
     f_flux_ratio = flux_ratio > 0.5
     f_good_early_snia = earlySNIa_score > 0.76


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes [346](https://github.com/astrolabsoftware/fink-filters/issues/346)

## What changes were proposed in this pull request?
min(flux) ---> min(10, min(abs(flux)))

### How is the issue this PR is referenced against solved with this PR?

min allowed flux is 10

## How was this patch tested?
locally