### PR TITLE
Fix log flux ratio calculation in filter.py

### DIFF
--- a/fink_filters/rubin/livestream/filter_early_snia_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_early_snia_candidate/filter.py
@@ -47,8 +47,8 @@ def early_snia_candidate(
     0
     """
     # calculate log flux ratio
-    f_min = extract_min_flux(diaObject).apply(lambda x: np.max([10, x]))
-    f_max = extract_max_flux(diaObject).apply(lambda x: x if x > 0 else 1e-10)
+    f_min = fu.extract_min_flux(diaObject).apply(lambda x: np.max([10, x]))
+    f_max = fu.extract_max_flux(diaObject).apply(lambda x: x if x > 0 else 1e-10)
 
     flux_ratio = np.log10(f_max / f_min)
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes [348](https://github.com/astrolabsoftware/fink-filters/issues/348)

## What changes were proposed in this pull request?

consider also objects where all measurements have negative flux

### How is the issue this PR is referenced against solved with this PR?

put a minimum of 10 for the max flux

## How was this patch tested?

locally