### PR TITLE
enh: adding a criteria to have only candidates with minimum two points

### DIFF
--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -1,5 +1,5 @@
 # Copyright 2019-2026 AstroLab Software
-# Author: Julien Peloton
+# Author: Julien Peloton, Camille Douzet
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Select LSST alerts new (< 48h first apparition) and potentially extragalactic"""
+"""Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic"""
 
 import pandas as pd
+
 import fink_filters.rubin.blocks as fb
 
-
-DESCRIPTION = (
-    "Select LSST alerts new (< 48h first apparition) and potentially extragalactic"
-)
+DESCRIPTION = "Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic"
 
 
 def extragalactic_new_candidate(
     diaSource: pd.DataFrame,
+    diaObject: pd.DataFrame,
     simbad_otype: pd.Series,
     mangrove_lum_dist: pd.Series,
     is_sso: pd.Series,
@@ -35,7 +34,7 @@ def extragalactic_new_candidate(
     legacydr8_zphot: pd.Series,
     firstDiaSourceMjdTaiFink: pd.Series,
 ) -> pd.Series:
-    """Select LSST alerts new (< 48h first apparition) and potentially extragalactic
+    """Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic
 
     Notes
     -----
@@ -98,7 +97,10 @@ def extragalactic_new_candidate(
     # 48h maximum
     f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 2.0
 
-    f_extragalactic_new = f_extragalactic_near_galaxy & f_new
+    # Minimum 2 points
+    f_sampling = diaObject.nDiaSources > 2
+
+    f_extragalactic_new = f_extragalactic_near_galaxy & f_new & f_sampling
 
     return f_extragalactic_new
 

--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Select LSST alerts new (< 5 days first apparition with a minimum of 2 points) and potentially extragalactic"""
+"""Select LSST alerts new (< 5days first apparition), bright (mag < 24), potentially extragalactic with a fading or rising rate passing the cuts"""
 
 import pandas as pd
 
 import fink_filters.rubin.blocks as fb
 import fink_filters.rubin.utils as fu
 
-DESCRIPTION = "Select LSST alerts new (< 5days first apparition with a minimum of 2 points) and potentially extragalactic"
+DESCRIPTION = "Select LSST alerts new (< 5days first apparition), bright (mag < 24), potentially extragalactic with a fading or rising rate passing the cuts"
 
 
 def has_two_points_same_band(
@@ -88,13 +88,13 @@ def extragalactic_new_candidate(
     legacydr8_zphot: pd.Series,
     firstDiaSourceMjdTaiFink: pd.Series,
 ) -> pd.Series:
-    """Select LSST alerts new (< 5 days first apparition with a minimum of 2 points) and potentially extragalactic
+    """Select LSST alerts new (< 5days first apparition), bright (mag < 24), potentially extragalactic with a fading or rising rate passing the cuts
 
     Notes
     -----
     Based on an extragalactic block, time cut, sampling cut, and rate cut.
     Rising alerts must have rate < -0.2 mag/day and last less than 3 days.
-    Fading alerts must have rate < 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
+    Fading alerts must have rate > 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
 
     Parameters
     ----------

--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -98,7 +98,7 @@ def extragalactic_new_candidate(
     f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 2.0
 
     # Minimum 2 points
-    f_sampling = diaObject.nDiaSources > 2
+    f_sampling = diaObject.nDiaSources >= 2
 
     f_extragalactic_new = f_extragalactic_near_galaxy & f_new & f_sampling
 

--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -92,7 +92,7 @@ def extragalactic_new_candidate(
 
     Notes
     -----
-    Based on an extragalactic block, time cut, sampling cut, and rate cut.
+    Based on a good quality block, an extragalactic block, time cut, sampling cut, and rate cut.
     Rising alerts must have rate < -0.2 mag/day and last less than 3 days.
     Fading alerts must have rate < 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
 
@@ -150,9 +150,12 @@ def extragalactic_new_candidate(
         legacydr8_zphot,
     )
 
+    f_good_quality = fb.b_good_quality(diaSource=diaSource)
+
     # 5 days maximum
     f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 5.0
 
+    # Keep only bright alerts (mag < 24, i.e. brighter than magnitude 24)
     f_bright = fu.flux_to_apparent_mag(diaSource.psfFlux) < 24
 
     # Minimum 2 points
@@ -172,6 +175,8 @@ def extragalactic_new_candidate(
         prev_flux
     )
     delta_time = diaSource.midpointMjdTai - prev_time
+
+    # Check that the rising is less then 3 days
     delta_time_rising = diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink
 
     rate = delta_mag / delta_time
@@ -183,51 +188,22 @@ def extragalactic_new_candidate(
     f_rate = f_rising | f_fading_ri | f_fading_gu
 
     f_extragalactic_new = (
-        f_extragalactic_near_galaxy & f_new & f_sampling & f_bright & f_rate
+        f_good_quality
+        & f_extragalactic_near_galaxy
+        & f_new
+        & f_sampling
+        & f_bright
+        & f_rate
     )
-
-    print(f"f_extragalactic_near_galaxy: {f_extragalactic_near_galaxy.sum()}")
-    print(f"f_new: {f_new.sum()}")
-    print(f"f_bright: {f_bright.sum()}")
-    print(f"f_sampling: {f_sampling.sum()}")
-    print(f"f_rate: {f_rate.sum()}")
-    print(f"extragalactic & new: {(f_extragalactic_near_galaxy & f_new).sum()}")
-    print(
-        f"extragalactic & new & bright: {(f_extragalactic_near_galaxy & f_new & f_bright).sum()}"
-    )
-    print(
-        f"extragalactic & new & bright & sampling: {(f_extragalactic_near_galaxy & f_new & f_bright & f_sampling).sum()}"
-    )
-    print(f"final: {f_extragalactic_new.sum()}")
-
-    with open("/home/libs/fink-filters/filter_stats.csv", "a") as f:
-        f.write(
-            f"{f_extragalactic_near_galaxy.sum()},"
-            f"{f_new.sum()},"
-            f"{f_bright.sum()},"
-            f"{f_sampling.sum()},"
-            f"{f_rate.sum()},"
-            f"{(f_extragalactic_near_galaxy & f_new).sum()},"
-            f"{(f_extragalactic_near_galaxy & f_new & f_bright).sum()},"
-            f"{(f_extragalactic_near_galaxy & f_new & f_bright & f_sampling).sum()},"
-            f"{f_extragalactic_new.sum()}\n"
-        )
 
     return f_extragalactic_new
 
 
 if __name__ == "__main__":
     """Test suite for filters"""
-    from pyspark.sql import SparkSession
+    # Run the test suite
 
     from fink_filters.tester import spark_unit_tests
 
-    data_path = "file:///home/libs/fink-filters/ftransfer_lsst_2026-03-16_32871"
-
-    spark = SparkSession.builder.getOrCreate()
-    spark.conf.set("spark.sql.parquet.enableVectorizedReader", "false")
     globs = globals()
-    globs["spark"] = spark
-    globs["df"] = spark.read.option("mergeSchema", "true").format("parquet").load(data_path)
-
-    spark_unit_tests(globs, load_rubin_df=False)
+    spark_unit_tests(globs, load_rubin_df=True)

--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -12,18 +12,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic"""
+"""Select LSST alerts new (< 5 days first apparition with a minimum of 2 points) and potentially extragalactic"""
 
 import pandas as pd
 
 import fink_filters.rubin.blocks as fb
+import fink_filters.rubin.utils as fu
 
-DESCRIPTION = "Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic"
+DESCRIPTION = "Select LSST alerts new (< 5days first apparition with a minimum of 2 points) and potentially extragalactic"
+
+
+def has_two_points_same_band(
+    diaSource: pd.DataFrame, diaObject: pd.DataFrame
+) -> pd.Series:
+    """Check if an object has at least 2 detections in the same band as the current alert.
+
+    Parameters
+    ----------
+    diaSource: pd.DataFrame
+        Full diaSource section of an alert (dictionary exploded)
+    diaObject: pd.DataFrame
+        Full diaObject section of an alert (dictionary exploded)
+
+    Returns
+    -------
+    out: pd.Series of booleans
+        True if at least 2 detections exist in the current alert's band, False otherwise.
+    """
+    result = pd.Series(False, index=diaSource.index)
+
+    for b in ["u", "g", "r", "i", "z", "y"]:
+        mask = diaSource.band == b
+        col = f"{b}_psfFluxNdata"
+        try:
+            result[mask] = diaObject.loc[mask, col] >= 2
+        except KeyError:
+            continue
+    return result
+
+
+def get_latest_source_same_band(row) -> dict | None:
+    """Return the most recent previous detection in the same band as the current alert.
+
+    Parameters
+    ----------
+    row: pd.Series
+        A single row from a DataFrame combining diaSource and prvDiaSources columns.
+
+    Returns
+    -------
+    out: dict or None
+        The most recent previous diaSource dict in the same band, or None if none exists.
+    """
+    sources = row["prvDiaSources"]
+    if sources is None or len(sources) == 0:
+        return None
+    current_band = row["band"]
+    same_band = [s for s in sources if s["band"] == current_band]
+    if not same_band:
+        return None
+    return max(same_band, key=lambda s: s["midpointMjdTai"])
 
 
 def extragalactic_new_candidate(
     diaSource: pd.DataFrame,
     diaObject: pd.DataFrame,
+    prvDiaSources: pd.Series,
     simbad_otype: pd.Series,
     mangrove_lum_dist: pd.Series,
     is_sso: pd.Series,
@@ -34,13 +88,13 @@ def extragalactic_new_candidate(
     legacydr8_zphot: pd.Series,
     firstDiaSourceMjdTaiFink: pd.Series,
 ) -> pd.Series:
-    """Select LSST alerts new (< 48h first apparition with a minimum of 2 points) and potentially extragalactic
+    """Select LSST alerts new (< 5 days first apparition with a minimum of 2 points) and potentially extragalactic
 
     Notes
     -----
-    Based on an extragalactic block and time cut
-
-
+    Based on an extragalactic block, time cut, sampling cut, and rate cut.
+    Rising alerts must have rate < -0.2 mag/day and last less than 3 days.
+    Fading alerts must have rate < 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
 
     Parameters
     ----------
@@ -48,6 +102,8 @@ def extragalactic_new_candidate(
         Full diaSource section of an alert (dictionary exploded)
     diaObject: pd.DataFrame
         Full diaObject section of an alert (dictionary exploded)
+    prvDiaSources: pd.Series
+        Series of lists of previous diaSource dicts for each alert
     simbad_otype: pd.Series
         Series containing labels from `xm.simbad_otype`
     mangrove_lum_dist: pd.Series
@@ -94,22 +150,84 @@ def extragalactic_new_candidate(
         legacydr8_zphot,
     )
 
-    # 48h maximum
-    f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 2.0
+    # 5 days maximum
+    f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 5.0
+
+    f_bright = fu.flux_to_apparent_mag(diaSource.psfFlux) < 24
 
     # Minimum 2 points
-    f_sampling = diaObject.nDiaSources >= 2
 
-    f_extragalactic_new = f_extragalactic_near_galaxy & f_new & f_sampling
+    f_sampling = has_two_points_same_band(diaSource, diaObject)
+
+    # Check rising and fading rate
+    df = pd.concat([diaSource, prvDiaSources.rename("prvDiaSources")], axis=1)
+    prev = df.apply(get_latest_source_same_band, axis=1)
+
+    prev_flux = prev.apply(lambda s: s["psfFlux"] if s is not None else float("nan"))
+    prev_time = prev.apply(
+        lambda s: s["midpointMjdTai"] if s is not None else float("nan")
+    )
+
+    delta_mag = fu.flux_to_apparent_mag(diaSource.psfFlux) - fu.flux_to_apparent_mag(
+        prev_flux
+    )
+    delta_time = diaSource.midpointMjdTai - prev_time
+    delta_time_rising = diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink
+
+    rate = delta_mag / delta_time
+
+    f_rising = (rate < -0.2) & (delta_time_rising < 3)
+
+    f_fading_ri = ((diaSource.band == "r") | (diaSource.band == "i")) & (rate < 0.2)
+    f_fading_gu = ((diaSource.band == "g") | (diaSource.band == "u")) & (rate > 0.5)
+    f_rate = f_rising | f_fading_ri | f_fading_gu
+
+    f_extragalactic_new = (
+        f_extragalactic_near_galaxy & f_new & f_sampling & f_bright & f_rate
+    )
+
+    print(f"f_extragalactic_near_galaxy: {f_extragalactic_near_galaxy.sum()}")
+    print(f"f_new: {f_new.sum()}")
+    print(f"f_bright: {f_bright.sum()}")
+    print(f"f_sampling: {f_sampling.sum()}")
+    print(f"f_rate: {f_rate.sum()}")
+    print(f"extragalactic & new: {(f_extragalactic_near_galaxy & f_new).sum()}")
+    print(
+        f"extragalactic & new & bright: {(f_extragalactic_near_galaxy & f_new & f_bright).sum()}"
+    )
+    print(
+        f"extragalactic & new & bright & sampling: {(f_extragalactic_near_galaxy & f_new & f_bright & f_sampling).sum()}"
+    )
+    print(f"final: {f_extragalactic_new.sum()}")
+
+    with open("/home/libs/fink-filters/filter_stats.csv", "a") as f:
+        f.write(
+            f"{f_extragalactic_near_galaxy.sum()},"
+            f"{f_new.sum()},"
+            f"{f_bright.sum()},"
+            f"{f_sampling.sum()},"
+            f"{f_rate.sum()},"
+            f"{(f_extragalactic_near_galaxy & f_new).sum()},"
+            f"{(f_extragalactic_near_galaxy & f_new & f_bright).sum()},"
+            f"{(f_extragalactic_near_galaxy & f_new & f_bright & f_sampling).sum()},"
+            f"{f_extragalactic_new.sum()}\n"
+        )
 
     return f_extragalactic_new
 
 
 if __name__ == "__main__":
     """Test suite for filters"""
-    # Run the test suite
+    from pyspark.sql import SparkSession
 
     from fink_filters.tester import spark_unit_tests
 
+    data_path = "file:///home/libs/fink-filters/ftransfer_lsst_2026-03-16_32871"
+
+    spark = SparkSession.builder.getOrCreate()
+    spark.conf.set("spark.sql.parquet.enableVectorizedReader", "false")
     globs = globals()
-    spark_unit_tests(globs, load_rubin_df=True)
+    globs["spark"] = spark
+    globs["df"] = spark.read.option("mergeSchema", "true").format("parquet").load(data_path)
+
+    spark_unit_tests(globs, load_rubin_df=False)

--- a/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_extragalactic_new_candidate/filter.py
@@ -92,7 +92,7 @@ def extragalactic_new_candidate(
 
     Notes
     -----
-    Based on a good quality block, an extragalactic block, time cut, sampling cut, and rate cut.
+    Based on an extragalactic block, time cut, sampling cut, and rate cut.
     Rising alerts must have rate < -0.2 mag/day and last less than 3 days.
     Fading alerts must have rate < 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
 
@@ -150,12 +150,9 @@ def extragalactic_new_candidate(
         legacydr8_zphot,
     )
 
-    f_good_quality = fb.b_good_quality(diaSource=diaSource)
-
     # 5 days maximum
     f_new = (diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink) < 5.0
 
-    # Keep only bright alerts (mag < 24, i.e. brighter than magnitude 24)
     f_bright = fu.flux_to_apparent_mag(diaSource.psfFlux) < 24
 
     # Minimum 2 points
@@ -175,25 +172,19 @@ def extragalactic_new_candidate(
         prev_flux
     )
     delta_time = diaSource.midpointMjdTai - prev_time
-
-    # Check that the rising is less then 3 days
     delta_time_rising = diaSource.midpointMjdTai - firstDiaSourceMjdTaiFink
 
     rate = delta_mag / delta_time
 
     f_rising = (rate < -0.2) & (delta_time_rising < 3)
 
-    f_fading_ri = ((diaSource.band == "r") | (diaSource.band == "i")) & (rate < 0.2)
+    f_fading_ri = ((diaSource.band == "r") | (diaSource.band == "i")) & (rate > 0.2)
     f_fading_gu = ((diaSource.band == "g") | (diaSource.band == "u")) & (rate > 0.5)
+
     f_rate = f_rising | f_fading_ri | f_fading_gu
 
     f_extragalactic_new = (
-        f_good_quality
-        & f_extragalactic_near_galaxy
-        & f_new
-        & f_sampling
-        & f_bright
-        & f_rate
+        f_extragalactic_near_galaxy & f_new & f_sampling & f_bright & f_rate
     )
 
     return f_extragalactic_new


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes https://github.com/astrolabsoftware/fink-filters/issues/357

## What changes were proposed in this pull request?

* The filter is now requiring a minimum of two points in the same band to pass.
* Rising alerts must have rate < -0.2 mag/day and last less than 3 days.
* Fading alerts must have rate > 0.2 mag/day in r/i bands, or > 0.5 mag/day in g/u bands.
* The magnitude must be less than 24.
* The cut on the age of the alert is now 5 days (the previous value was 48 hours)
