### PR TITLE
enh: fixing fink url portal to the current one

### DIFF
--- a/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
@@ -14,23 +14,20 @@
 # limitations under the License.
 """Return alerts considered as KN candidates from contextual consideration"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
-
-import numpy as np
-import pandas as pd
 import datetime
-import requests
 import logging
 import os
 
-from astropy.coordinates import SkyCoord
-from astropy.coordinates import Angle
+import numpy as np
+import pandas as pd
+import requests
 from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from astroquery.sdss import SDSS
-
 from fink_utils.xmatch.simbad import return_list_of_eg_host
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
 
 from fink_filters import __file__
 from fink_filters.tester import spark_unit_tests
@@ -79,13 +76,15 @@ def perform_classification(
             dec=np.array(pdf_mangrove.dec, dtype=float) * u.degree,
         )
 
-        pdf = pd.DataFrame.from_dict({
-            "fid": fid[f_kn],
-            "ra": ra[f_kn],
-            "dec": dec[f_kn],
-            "mag": magpsf[f_kn],
-            "err_mag": sigmapsf[f_kn],
-        })
+        pdf = pd.DataFrame.from_dict(
+            {
+                "fid": fid[f_kn],
+                "ra": ra[f_kn],
+                "dec": dec[f_kn],
+                "mag": magpsf[f_kn],
+                "err_mag": sigmapsf[f_kn],
+            }
+        )
 
         # identify galaxy somehow close to each alert. Distances are in Mpc
         idx_mangrove, idxself, _, _ = SkyCoord(
@@ -380,7 +379,7 @@ def early_kn_candidates(
     for i, alertID in enumerate(objectId[mask_filter].to_numpy()):
         # information to send
         alert_text = """
-            *Fink Science Portal:* <https://fink-portal.org/{}|{}>
+            *Fink Science Portal:* <https://ztf.fink-portal.org/{}|{}>
             """.format(alertID, alertID)
         skyportal_text = """
             *SkyPortal:* <https://skyportal-icare.ijclab.in2p3.fr/source/{}|{}>

--- a/fink_filters/ztf/livestream/filter_early_sn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_early_sn_candidates/filter.py
@@ -14,18 +14,15 @@
 # limitations under the License.
 """Return alerts considered as Early SN Ia candidates"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
-
-from fink_utils.xmatch.simbad import return_list_of_eg_host
-from fink_utils.tg_bot.utils import get_curve
-from fink_utils.tg_bot.utils import get_cutout
-from fink_utils.tg_bot.utils import msg_handler_tg
-
-from fink_filters.tester import spark_unit_tests
+import os
 
 import pandas as pd
-import os
+from fink_utils.tg_bot.utils import get_curve, get_cutout, msg_handler_tg
+from fink_utils.xmatch.simbad import return_list_of_eg_host
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
+
+from fink_filters.tester import spark_unit_tests
 
 
 def early_sn_candidates_(
@@ -168,18 +165,20 @@ def early_sn_candidates(
         classtar,
     )
 
-    pdf = pd.DataFrame({
-        "objectId": objectId,
-        "magpsf": cmagpsfc,
-        "sigmapsf": csigmapsfc,
-        "diffmaglim": cdiffmaglimc,
-        "fid": cfidc,
-        "jd": cjdc,
-        "snn_snia_vs_nonia": snn_snia_vs_nonia,
-        "snn_sn_vs_all": snn_sn_vs_all,
-        "rf_snia_vs_nonia": rf_snia_vs_nonia,
-        "cstampDatac": cstampDatac,
-    })
+    pdf = pd.DataFrame(
+        {
+            "objectId": objectId,
+            "magpsf": cmagpsfc,
+            "sigmapsf": csigmapsfc,
+            "diffmaglim": cdiffmaglimc,
+            "fid": cfidc,
+            "jd": cjdc,
+            "snn_snia_vs_nonia": snn_snia_vs_nonia,
+            "snn_sn_vs_all": snn_sn_vs_all,
+            "rf_snia_vs_nonia": rf_snia_vs_nonia,
+            "cstampDatac": cstampDatac,
+        }
+    )
 
     # Loop over matches
     if ("FINK_TG_TOKEN" in os.environ) and os.environ["FINK_TG_TOKEN"] != "":
@@ -198,7 +197,7 @@ def early_sn_candidates(
             cutout = get_cutout(cutout=alert["cstampDatac"])
 
             text = """
-*Object ID*: [{}](https://fink-portal.org/{})
+*Object ID*: [{}](https://ztf.fink-portal.org/{})
 *Scores:*\n- Early SN Ia: {:.2f}\n- Ia SN vs non-Ia SN: {:.2f}\n- SN Ia and Core-Collapse vs non-SN: {:.2f}
             """.format(
                 alert["objectId"],

--- a/fink_filters/ztf/livestream/filter_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_kn_candidates/filter.py
@@ -14,23 +14,20 @@
 # limitations under the License.
 """Return alerts considered as KN candidates from machine learning consideration"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
+import datetime
+import logging
+import os
 
 import numpy as np
 import pandas as pd
-import datetime
 import requests
-import os
-import logging
-
-from astropy.coordinates import SkyCoord
-from astropy.coordinates import Angle
 from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
-
 from fink_utils.photometry.conversion import dc_mag
 from fink_utils.xmatch.simbad import return_list_of_eg_host
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
 
 from fink_filters.tester import spark_unit_tests
 
@@ -242,16 +239,18 @@ def kn_candidates(
         if sum(m) < 2:
             continue
         # DC mag (history + last measurement)
-        mag_hist, err_hist = np.array([
-            dc_mag(k[0], k[1], k[2], k[3], k[4])
-            for k in zip(
-                cmagpsfc[f_kn].to_numpy()[i][m][-2:],
-                csigmapsfc[f_kn].to_numpy()[i][m][-2:],
-                cmagnrc[f_kn].to_numpy()[i][m][-2:],
-                csigmagnrc[f_kn].to_numpy()[i][m][-2:],
-                cisdiffposc[f_kn].to_numpy()[i][m][-2:],
-            )
-        ]).T
+        mag_hist, err_hist = np.array(
+            [
+                dc_mag(k[0], k[1], k[2], k[3], k[4])
+                for k in zip(
+                    cmagpsfc[f_kn].to_numpy()[i][m][-2:],
+                    csigmapsfc[f_kn].to_numpy()[i][m][-2:],
+                    cmagnrc[f_kn].to_numpy()[i][m][-2:],
+                    csigmagnrc[f_kn].to_numpy()[i][m][-2:],
+                    cisdiffposc[f_kn].to_numpy()[i][m][-2:],
+                )
+            ]
+        ).T
 
         # Grab the last measurement and its error estimate
         mag = mag_hist[-1]
@@ -269,7 +268,7 @@ def kn_candidates(
 
         # information to send
         alert_text = """
-            *Fink Science Portal:* <https://fink-portal.org/{}|{}>
+            *Fink Science Portal:* <https://ztf.fink-portal.org/{}|{}>
             """.format(alertID, alertID)
         skyportal_text = """
             *SkyPortal:* <https://skyportal-icare.ijclab.in2p3.fr/source/{}|{}>

--- a/fink_filters/ztf/livestream/filter_magnetic_cvs/filter.py
+++ b/fink_filters/ztf/livestream/filter_magnetic_cvs/filter.py
@@ -14,22 +14,18 @@
 # limitations under the License.
 """Return alerts with a match in a magnetic cataclysmic variables catalog"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
-
-from fink_science.ztf.xmatch.utils import cross_match_astropy
-from fink_filters import __file__
-
-from fink_utils.tg_bot.utils import get_curve
-from fink_utils.tg_bot.utils import msg_handler_tg
-
-from astropy.coordinates import SkyCoord
-from astropy import units as u
-
 import os
+
 import numpy as np
 import pandas as pd
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from fink_science.ztf.xmatch.utils import cross_match_astropy
+from fink_utils.tg_bot.utils import get_curve, msg_handler_tg
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
 
+from fink_filters import __file__
 from fink_filters.tester import spark_unit_tests
 
 
@@ -45,7 +41,7 @@ def send_to_telegram(pdf, channel):
             )
 
             text = """
-*Object ID*: [{}](https://fink-portal.org/{})
+*Object ID*: [{}](https://ztf.fink-portal.org/{})
 *Name*: {}
 *RA/Dec coordinates*: {} {}
             """.format(
@@ -93,11 +89,13 @@ def magnetic_cvs_(ra, dec):
     curdir = os.path.dirname(os.path.abspath(__file__))
     pdf_mcvs = pd.read_csv(curdir + "/data/magnetic_cataclysmic_variables.csv")
 
-    pdf = pd.DataFrame({
-        "ra": ra.to_numpy(),
-        "dec": dec.to_numpy(),
-        "candid": range(len(ra)),
-    })
+    pdf = pd.DataFrame(
+        {
+            "ra": ra.to_numpy(),
+            "dec": dec.to_numpy(),
+            "candid": range(len(ra)),
+        }
+    )
 
     # create catalogs
     catalog_ztf = SkyCoord(
@@ -166,12 +164,14 @@ def magnetic_cvs(objectId, isdiffpos, ra, dec) -> pd.Series:
 
     mask = names != "Unknown"
     if len(names[mask]) > 0:
-        pdf = pd.DataFrame({
-            "objectId": objectId[mask],
-            "ra": ra[mask],
-            "dec": dec[mask],
-            "name": names[mask],
-        })
+        pdf = pd.DataFrame(
+            {
+                "objectId": objectId[mask],
+                "ra": ra[mask],
+                "dec": dec[mask],
+                "name": names[mask],
+            }
+        )
         send_to_telegram(pdf, channel="@fink_magnetic_cv_stars")
 
     return pd.Series(mask)

--- a/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
@@ -14,25 +14,22 @@
 # limitations under the License.
 """Return alerts considered as KN candidates using rate-based consideration"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
+import datetime
+import logging
+import os
 
 import numpy as np
 import pandas as pd
-import datetime
 import requests
-import os
-import logging
-from scipy.optimize import curve_fit
-
-from astropy.coordinates import SkyCoord
-from astropy.coordinates import Angle
 from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from astroquery.sdss import SDSS
-
 from fink_utils.photometry.conversion import dc_mag
 from fink_utils.xmatch.simbad import return_list_of_eg_host
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
+from scipy.optimize import curve_fit
 
 from fink_filters.tester import spark_unit_tests
 
@@ -132,16 +129,18 @@ def perform_classification(
         if sum(m) < 2:
             continue
         # DC mag (history + last measurement)
-        mag_hist, err_hist = np.array([
-            dc_mag(k[0], k[1], k[2], k[3], k[4])
-            for k in zip(
-                cmagpsfc[f_kn].to_numpy()[i][m],
-                csigmapsfc[f_kn].to_numpy()[i][m],
-                cmagnrc[f_kn].to_numpy()[i][m],
-                csigmagnrc[f_kn].to_numpy()[i][m],
-                cisdiffposc[f_kn].to_numpy()[i][m],
-            )
-        ]).T
+        mag_hist, err_hist = np.array(
+            [
+                dc_mag(k[0], k[1], k[2], k[3], k[4])
+                for k in zip(
+                    cmagpsfc[f_kn].to_numpy()[i][m],
+                    csigmapsfc[f_kn].to_numpy()[i][m],
+                    cmagnrc[f_kn].to_numpy()[i][m],
+                    csigmagnrc[f_kn].to_numpy()[i][m],
+                    cisdiffposc[f_kn].to_numpy()[i][m],
+                )
+            ]
+        ).T
 
         # remove abnormal values
         mask_outliers = mag_hist < 21
@@ -416,7 +415,7 @@ def rate_based_kn_candidates(
         # information to send
         dict_filt = {1: "g", 2: "r"}
         alert_text = """
-            *Fink Science Portal:* <https://fink-portal.org/{}|{}>
+            *Fink Science Portal:* <https://ztf.fink-portal.org/{}|{}>
             """.format(alertID, alertID)
         skyportal_text = """
             *SkyPortal:* <https://skyportal-icare.ijclab.in2p3.fr/source/{}|{}>

--- a/fink_filters/ztf/livestream/filter_tns_match/filter.py
+++ b/fink_filters/ztf/livestream/filter_tns_match/filter.py
@@ -14,18 +14,15 @@
 # limitations under the License.
 """Return alerts with a counterpart in TNS"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+import os
+
+import pandas as pd
+from astropy.coordinates import SkyCoord, get_constellation
+from fink_utils.tg_bot.utils import get_curve, get_cutout, msg_handler_tg
+from pyspark.sql.functions import PandasUDFType, pandas_udf
 from pyspark.sql.types import BooleanType
 
-from fink_utils.tg_bot.utils import get_curve
-from fink_utils.tg_bot.utils import get_cutout
-from fink_utils.tg_bot.utils import msg_handler_tg
-
 from fink_filters.tester import spark_unit_tests
-
-from astropy.coordinates import SkyCoord, get_constellation
-import pandas as pd
-import os
 
 
 def extract_url_from_class(tns: str) -> str:
@@ -162,13 +159,15 @@ def tns_match(
     """
     series = tns_match_(tns, jd, jdstarthist)
 
-    pdf = pd.DataFrame({
-        "objectId": objectId,
-        "ra": ra,
-        "dec": dec,
-        "tns": tns,
-        "dt": jd - jdstarthist,
-    })
+    pdf = pd.DataFrame(
+        {
+            "objectId": objectId,
+            "ra": ra,
+            "dec": dec,
+            "tns": tns,
+            "dt": jd - jdstarthist,
+        }
+    )
 
     # Loop over matches
     if ("FINK_TG_TOKEN" in os.environ) and os.environ["FINK_TG_TOKEN"] != "":
@@ -187,7 +186,7 @@ def tns_match(
             text = """
 🔭 Appeared {:.0f} days ago
 
-*Object name*: {} (inspect it on the [portal](https://fink-portal.org/{}))
+*Object name*: {} (inspect it on the [portal](https://ztf.fink-portal.org/{}))
 *Classification*: [{}]({})
 *Constellation*: {}
             """.format(

--- a/fink_filters/ztf/livestream/filter_yso_spicy_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_yso_spicy_candidates/filter.py
@@ -14,16 +14,15 @@
 # limitations under the License.
 """Return alerts with a match in the SPICY catalog"""
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import BooleanType
-
-from fink_utils.tg_bot.utils import get_curve, msg_handler_tg
-
-from fink_filters.tester import spark_unit_tests
+import os
 
 import numpy as np
 import pandas as pd
-import os
+from fink_utils.tg_bot.utils import get_curve, msg_handler_tg
+from pyspark.sql.functions import PandasUDFType, pandas_udf
+from pyspark.sql.types import BooleanType
+
+from fink_filters.tester import spark_unit_tests
 
 
 def r2_score(jd, magpsf, fid, min_points=5):
@@ -130,17 +129,19 @@ def yso_spicy_candidates(
     r2_lim = 0.6  # minimum required r2
 
     # convert to pandas
-    pdf = pd.DataFrame({
-        "objectId": objectId,
-        "magpsf": cmagpsfc,
-        "sigmapsf": csigmapsfc,
-        "diffmaglim": cdiffmaglimc,
-        "fid": cfidc,
-        "jd": cjdc,
-        "spicy_id": spicy_id,
-        "spicy_class": spicy_class,
-        "linear_fit_slope": linear_fit_slope,
-    })
+    pdf = pd.DataFrame(
+        {
+            "objectId": objectId,
+            "magpsf": cmagpsfc,
+            "sigmapsf": csigmapsfc,
+            "diffmaglim": cdiffmaglimc,
+            "fid": cfidc,
+            "jd": cjdc,
+            "spicy_id": spicy_id,
+            "spicy_class": spicy_class,
+            "linear_fit_slope": linear_fit_slope,
+        }
+    )
 
     # select spicy objecs, N
     mask_spicy = ~spicy_class.isin(["Unknown", None, np.nan])
@@ -165,7 +166,7 @@ def yso_spicy_candidates(
                 origin="API",
             )
 
-            hyperlink = "[{}](https://fink-portal.org/{}): ID {} ({})".format(
+            hyperlink = "[{}](https://ztf.fink-portal.org/{}): ID {} ({})".format(
                 alert["objectId"],
                 alert["objectId"],
                 alert["spicy_id"],


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes https://github.com/astrolabsoftware/fink-filters/issues/361

## What changes were proposed in this pull request?

Since LSST survey support, there are two URLs, so we need to move from https://fink-portal.org/.... to https://ztf.fink-portal.org/....

I don't have change fink_filters/ztf/filter_anomaly_notification/filter.py since it has been done in an other PR.