### PR TITLE
add 1% uniform random sample filter 

### DIFF
--- a/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
+++ b/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
@@ -1,9 +1,23 @@
-"Select 1% of all live alerts in a uniformly random way"
+# Copyright 2026 AstroLab Software
+# Author: Mohammed Chamma
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Select 1% of all live alerts in a uniformly random way"""
 import pandas as pd
 
 DESCRIPTION = "Select 1% of all live alerts in a uniformly random way"
 
-def get_random_alert(diaSourceId: pd.Series) -> pd.Series:
+def uniform_sample(diaSourceId: pd.Series) -> pd.Series:
     """
 
     Examples
@@ -14,7 +28,7 @@ def get_random_alert(diaSourceId: pd.Series) -> pd.Series:
     >>> # df = pd.read_parquet('dataset/rubin_test_data_10_0.parquet')
     >>> # df = spark.read.format('parquet').load('dataset/rubin_test_data_10_0.parquet')
     >>> totalcount = df.count()
-    >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.get_random_alert'
+    >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.uniform_sample'
     >>> df = apply_user_defined_filter(df, f)
     >>> ratio = df.count() / totalcount
     >>> (0.005 <= ratio < 0.02) # check we are between 0.5% and 2%

--- a/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
+++ b/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Select 1% of all live alerts in a uniformly random way"""
+
 import pandas as pd
 
 DESCRIPTION = "Select 1% of all live alerts in a uniformly random way"
+
 
 def uniform_sample(diaSourceId: pd.Series) -> pd.Series:
     """Select 1% of all live alerts in a uniformly random way.
@@ -32,7 +34,7 @@ def uniform_sample(diaSourceId: pd.Series) -> pd.Series:
         pd.Series of random diaSourceIds
 
     Examples
-    ---------
+    --------
     >>> from fink_utils.spark.utils import apply_user_defined_filter
     >>> totalcount = df.count()
     >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.filter.uniform_sample'
@@ -43,7 +45,9 @@ def uniform_sample(diaSourceId: pd.Series) -> pd.Series:
     """
     return diaSourceId % 113 == 0
 
+
 if __name__ == "__main__":
     from fink_filters.tester import spark_unit_tests
+
     globs = globals()
     spark_unit_tests(globs, load_rubin_df=True)

--- a/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
+++ b/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
@@ -1,0 +1,30 @@
+"Select 1% of all live alerts in a uniformly random way"
+import pandas as pd
+
+DESCRIPTION = "Select 1% of all live alerts in a uniformly random way"
+
+def get_random_alert(diaSourceId: pd.Series) -> pd.Series:
+    """
+
+    Examples
+    ---------
+    >>> import numpy as np
+    >>> import os
+    >>> from fink_utils.spark.utils import apply_user_defined_filter
+    >>> # df = pd.read_parquet('dataset/rubin_test_data_10_0.parquet')
+    >>> # df = spark.read.format('parquet').load('dataset/rubin_test_data_10_0.parquet')
+    >>> totalcount = df.count()
+    >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.get_random_alert'
+    >>> df = apply_user_defined_filter(df, f)
+    >>> ratio = df.count() / totalcount
+    >>> (0.005 <= ratio < 0.02) # check we are between 0.5% and 2%
+    True
+    """
+    # diaSourceId % 113 == 0
+    random_alert = diaSourceId.apply(lambda x: x % 113 == 0)
+    return random_alert
+
+if __name__ == "__main__":
+    from fink_filters.tester import spark_unit_tests
+    globs = globals()
+    spark_unit_tests(globs, load_rubin_df=True)	

--- a/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
+++ b/fink_filters/rubin/livestream/filter_uniform_sample/filter.py
@@ -18,27 +18,32 @@ import pandas as pd
 DESCRIPTION = "Select 1% of all live alerts in a uniformly random way"
 
 def uniform_sample(diaSourceId: pd.Series) -> pd.Series:
-    """
+    """Select 1% of all live alerts in a uniformly random way.
+    Alerts are filtered by `diaSourceId % 113==0`.
+
+    Parameters
+    ----------
+    diaSourceId: pd.Series
+        The diaSourceId for the alert assigned by the Rubin/LSST Pipeline
+
+    Returns
+    -------
+    random_alerts: pd.Series
+        pd.Series of random diaSourceIds
 
     Examples
     ---------
-    >>> import numpy as np
-    >>> import os
     >>> from fink_utils.spark.utils import apply_user_defined_filter
-    >>> # df = pd.read_parquet('dataset/rubin_test_data_10_0.parquet')
-    >>> # df = spark.read.format('parquet').load('dataset/rubin_test_data_10_0.parquet')
     >>> totalcount = df.count()
-    >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.uniform_sample'
-    >>> df = apply_user_defined_filter(df, f)
-    >>> ratio = df.count() / totalcount
-    >>> (0.005 <= ratio < 0.02) # check we are between 0.5% and 2%
+    >>> f = 'fink_filters.rubin.livestream.filter_uniform_sample.filter.uniform_sample'
+    >>> rand_df = apply_user_defined_filter(df, f)
+    >>> ratio = rand_df.count() / totalcount
+    >>> (0.005 <= ratio < 0.04) # check we are between 0.5% and 4%
     True
     """
-    # diaSourceId % 113 == 0
-    random_alert = diaSourceId.apply(lambda x: x % 113 == 0)
-    return random_alert
+    return diaSourceId % 113 == 0
 
 if __name__ == "__main__":
     from fink_filters.tester import spark_unit_tests
     globs = globals()
-    spark_unit_tests(globs, load_rubin_df=True)	
+    spark_unit_tests(globs, load_rubin_df=True)


### PR DESCRIPTION
Linked to issue(s): Closes #355 

## What changes were proposed in this pull request?

This filter returns approximately 1% of the stream uniformly and randomly by applying the condition 
```diaSourceId % 113 == 0```

We picked and tested this condition based on conversations with members in the LSST-DESC collaboration. A mod 100 would also in principle work however there were concerns Rubin might perform some processing on every 100th alert that would bias the `diaSourceId`s, so the nearest prime number was chosen.

## How is the issue this PR is referenced against solved with this PR?
Implements the requested filter.

## How was this patch tested?
We created a Fink Data Transfer topic for all alerts from February 1st 2026 to March 2026, with the condition ```diaSource.diaSourceId % 113 == 0```.
This selected 9,292,872 alerts (487.43 GB)
Upon ingesting the entire kafka topic we pulled 81,924 alerts, or 0.88% of all alerts. 
If the filter is accepted subsequent testing will need to be performed to ensure the sample is uniformly random (for example, uniformly distributed on the sky, etc). We did not yet perform any such testing on the downloaded alerts.

In terms of the doc-test, I am having trouble getting it to run. 
I cannot seem to load the test data in the repo when running the test suite in the container specified in the [docs](https://doc.lsst.fink-broker.org/developers/filter_tutorial/). I also get an `AttributeError: 'NoneType' object has no attribute '__code__'` when trying to use `apply_user_defined_filter` (following the [linked filter](https://github.com/astrolabsoftware/fink-filters/blob/be30474e10d041afe8da992ac1fe37da71db230f/fink_filters/filter_early_sn_candidates/filter.py#L136-L157) from the docs as an example). Open to any suggestions!

As you can see in the doc test I would like to load some alerts, apply the filter, and then check that the proportion selected is between 0.5% and 2%