### PR TITLE
Add a block that returns alerts outside the galactic plane (+/- |5| deg)

### DIFF
--- a/fink_filters/rubin/blocks.py
+++ b/fink_filters/rubin/blocks.py
@@ -47,7 +47,7 @@ def b_is_solar_system(is_sso: pd.Series) -> pd.Series:
     return is_sso
 
 
-def b_outside_galactic_plane(ra: pd.Series, dec: pd.Series) -> pd.Series:
+def b_outside_galactic_plane_20_deg(ra: pd.Series, dec: pd.Series) -> pd.Series:
     """Return alerts outside the galactic plane (+/- |20| deg)
 
     Parameters
@@ -65,7 +65,7 @@ def b_outside_galactic_plane(ra: pd.Series, dec: pd.Series) -> pd.Series:
     Examples
     --------
     >>> from fink_filters.rubin.utils import apply_block
-    >>> df2 = apply_block(df, "fink_filters.rubin.blocks.b_outside_galactic_plane")
+    >>> df2 = apply_block(df, "fink_filters.rubin.blocks.b_outside_galactic_plane_20_deg")
     >>> df2.count()
     27
     """
@@ -487,7 +487,7 @@ def extragalactic_base(
     mask_unknown_simbad = b_xmatched_simbad_unknown(simbad_otype)
 
     # Outside galactic plane
-    mask_outside_galactic_plane = b_outside_galactic_plane(diaSource.ra, diaSource.dec)
+    mask_outside_galactic_plane = b_outside_galactic_plane_20_deg(diaSource.ra, diaSource.dec)
 
     # Not a roid
     mask_roid = b_is_solar_system(is_sso)

--- a/fink_filters/rubin/blocks.py
+++ b/fink_filters/rubin/blocks.py
@@ -75,6 +75,34 @@ def b_outside_galactic_plane(ra: pd.Series, dec: pd.Series) -> pd.Series:
     return pd.Series(mask_away_from_galactic_plane)
 
 
+def b_outside_galactic_plane_5_deg(ra: pd.Series, dec: pd.Series) -> pd.Series:
+    """Return alerts outside the galactic plane (+/- |5| deg)
+
+    Parameters
+    ----------
+    ra: pd.Series of float
+        RA in degree
+    dec: pd.Series of float
+        DEC in degree
+
+    Returns
+    -------
+    out: pd.Series of booleans
+        True if outside the plane. False otherwise
+
+    Examples
+    --------
+    >>> from fink_filters.rubin.utils import apply_block
+    >>> df2 = apply_block(df, "fink_filters.rubin.blocks.b_outside_galactic_plane_5_deg")
+    >>> df2.count()
+    27
+    """
+    coords = SkyCoord(ra.astype(float), dec.astype(float), unit="deg")
+    b = coords.galactic.b.deg
+    mask_away_from_galactic_plane = np.abs(b) > 5
+    return pd.Series(mask_away_from_galactic_plane)
+
+
 def b_xmatched_simbad_galaxy(simbad_otype: pd.Series) -> pd.Series:
     """Return alerts xmatched to a galaxy with SIMBAD.
 

--- a/fink_filters/rubin/blocks.py
+++ b/fink_filters/rubin/blocks.py
@@ -75,15 +75,13 @@ def b_outside_galactic_plane_20_deg(diaSource: pd.DataFrame) -> pd.Series:
     return pd.Series(mask_away_from_galactic_plane)
 
 
-def b_outside_galactic_plane_5_deg(ra: pd.Series, dec: pd.Series) -> pd.Series:
+def b_outside_galactic_plane_5_deg(diaSource: pd.DataFrame) -> pd.Series:
     """Return alerts outside the galactic plane (+/- |5| deg)
 
     Parameters
     ----------
-    ra: pd.Series of float
-        RA in degree
-    dec: pd.Series of float
-        DEC in degree
+    diaSource: pd.DataFrame
+        Field containing `ra` and `dec` in degree
 
     Returns
     -------
@@ -97,7 +95,9 @@ def b_outside_galactic_plane_5_deg(ra: pd.Series, dec: pd.Series) -> pd.Series:
     >>> df2.count()
     27
     """
-    coords = SkyCoord(ra.astype(float), dec.astype(float), unit="deg")
+    coords = SkyCoord(
+        diaSource.ra.astype(float), diaSource.dec.astype(float), unit="deg"
+    )
     b = coords.galactic.b.deg
     mask_away_from_galactic_plane = np.abs(b) > 5
     return pd.Series(mask_away_from_galactic_plane)

--- a/fink_filters/rubin/livestream/filter_hostless_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_hostless_candidate/filter.py
@@ -59,7 +59,7 @@ def hostless_candidate(
     f_hostless = (
         f_good_quality
         & (elephant_kstest_template < 0.95)
-        & f_outside_galactic_plant
+        & f_outside_galactic_plane
         & f_bright
     )
 

--- a/fink_filters/rubin/livestream/filter_hostless_candidate/filter.py
+++ b/fink_filters/rubin/livestream/filter_hostless_candidate/filter.py
@@ -54,7 +54,7 @@ def hostless_candidate(
     """
     # Good quality
     f_good_quality = fb.b_good_quality(diaSource)
-    f_outside_galactic_plant = fb.b_outside_galactic_plane(diaSource.ra, diaSource.dec)
+    f_outside_galactic_plant = fb.b_outside_galactic_plane_20_deg(diaSource.ra, diaSource.dec)
     f_bright = fu.flux_to_apparent_mag(diaSource.psfFlux) <= 21.5
     f_hostless = (
         f_good_quality


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes https://github.com/astrolabsoftware/fink-filters/issues/370#issue-4185503706

## What changes were proposed in this pull request?

Adding a block in fink_filters/rubin/blocks.py that excludes alerts within the galactic plane (+/- |5| deg).
New block name : b_outside_galactic_plane_5_deg
This block is highly inspired from the already existing b_outside_galactic_plane block. I just changed the value of the mask for the galactic latitude from 20 deg to 5 deg.
