### PR TITLE
[ZTF] instrument Slack data retrieval to understand errors

### DIFF
--- a/fink_filters/__init__.py
+++ b/fink_filters/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "7.33"
+__version__ = "7.34"

--- a/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
@@ -577,7 +577,7 @@ def get_cutout(ztf_id):
         "https://api.ztf.fink-portal.org/api/v1/cutouts",
         json={"objectId": ztf_id, "kind": "Science", "output-format": "array"},
     )
-    if not status_check(r, "get cutouts ({})".format(ztf_id)):
+    if not status_check(r, "Anomaly: get cutouts ({})".format(ztf_id)):
         return io.BytesIO()
     data = np.log(np.array(r.json()["b:cutoutScience_stampData"], dtype=float))
     plt.axis("off")
@@ -608,8 +608,8 @@ def get_curve(ztf_id, last_days=None):
         "https://api.ztf.fink-portal.org/api/v1/objects",
         json={"objectId": ztf_id, "withupperlim": "True"},
     )
-    if not status_check(r, "getting curve ({})".format(ztf_id)):
-        return None
+    if not status_check(r, "Anomaly: get curve ({})".format(ztf_id)):
+        return io.BytesIO()
 
     # Format output in a DataFrame
     pdf = pd.read_json(io.BytesIO(r.content))

--- a/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
@@ -245,12 +245,15 @@ def get_data_permalink_slack(
             ]
         )
         time.sleep(3)
-    except SlackApiError as e:
+    except (SlackApiError, AttributeError) as e:
         if e.response["ok"] is False:
             send_post_request_with_retry(
                 session=session,
                 url=f"https://api.telegram.org/bot{os.environ[tg_token_env]}/sendMessage",
-                data={"chat_id": "@fink_test", "text": e.response["error"]},
+                data={
+                    "chat_id": "@fink_test",
+                    "text": "{}: {}".format(ztf_id, e.response["error"]),
+                },
                 timeout=60,
                 source="slack_api_error",
             )

--- a/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
+++ b/fink_filters/ztf/filter_anomaly_notification/filter_utils.py
@@ -577,7 +577,7 @@ def get_cutout(ztf_id):
         "https://api.ztf.fink-portal.org/api/v1/cutouts",
         json={"objectId": ztf_id, "kind": "Science", "output-format": "array"},
     )
-    if not status_check(r, "get cutouts"):
+    if not status_check(r, "get cutouts ({})".format(ztf_id)):
         return io.BytesIO()
     data = np.log(np.array(r.json()["b:cutoutScience_stampData"], dtype=float))
     plt.axis("off")
@@ -608,7 +608,7 @@ def get_curve(ztf_id, last_days=None):
         "https://api.ztf.fink-portal.org/api/v1/objects",
         json={"objectId": ztf_id, "withupperlim": "True"},
     )
-    if not status_check(r, "getting curve"):
+    if not status_check(r, "getting curve ({})".format(ztf_id)):
         return None
 
     # Format output in a DataFrame


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #385

## What changes were proposed in this pull request?

This PR is a way to understand which objects are triggering an error for the anomaly detection bot. This PR does not solve the problem, as the problem seems to arise at the level of the database. 

- add AttributeError catching when getting data from Fink. 
- replace `None` by an empty buffer if LC retrieval fails
- add the ZTF ID to the payload sent to the TG error channel in order to better track which object is triggering an error.

## How was this patch tested?

CI
