### PR TITLE
Prevent KN filters to crash if SDSS fails to return correct structure

### DIFF
--- a/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
@@ -154,7 +154,7 @@ def perform_classification(
 
             type_close_objects = []
             if table is not None:
-                type_close_objects = table["type"]
+                type_close_objects = table.get("type", 0)
             # types: 0: UNKNOWN, 1: STAR, 2: GALAXY, 3: QSO, 4: HIZ_QSO,
             # 5: SKY, 6: STAR_LATE, 7: GAL_EM
             to_remove_types = [1, 3, 4, 6]

--- a/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_early_kn_candidates/filter.py
@@ -153,8 +153,8 @@ def perform_classification(
                 table = None
 
             type_close_objects = []
-            if table is not None:
-                type_close_objects = table.get("type", 0)
+            if (table is not None) and (table.colnames != ["<html><head>"]):
+                type_close_objects = table["type"]
             # types: 0: UNKNOWN, 1: STAR, 2: GALAXY, 3: QSO, 4: HIZ_QSO,
             # 5: SKY, 6: STAR_LATE, 7: GAL_EM
             to_remove_types = [1, 3, 4, 6]

--- a/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
@@ -186,8 +186,8 @@ def perform_classification(
                 log.warning("Error with SDSS server: {}".format(e))
                 table = None
             type_close_objects = []
-            if table is not None:
-                type_close_objects = table.get("type", 0)
+            if (table is not None) and (table.colnames != ["<html><head>"]):
+                type_close_objects = table["type"]
             # types: 0: UNKNOWN, 1: STAR, 2: GALAXY, 3: QSO, 4: HIZ_QSO,
             # 5: SKY, 6: STAR_LATE, 7: GAL_EM
             to_remove_types = [1, 3, 4, 6]

--- a/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
+++ b/fink_filters/ztf/livestream/filter_rate_based_kn_candidates/filter.py
@@ -187,7 +187,7 @@ def perform_classification(
                 table = None
             type_close_objects = []
             if table is not None:
-                type_close_objects = table["type"]
+                type_close_objects = table.get("type", 0)
             # types: 0: UNKNOWN, 1: STAR, 2: GALAXY, 3: QSO, 4: HIZ_QSO,
             # 5: SKY, 6: STAR_LATE, 7: GAL_EM
             to_remove_types = [1, 3, 4, 6]


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #402

## What changes were proposed in this pull request?

Change the way to access the `type` key in the `table` dictionary to prevent crash when it does not exist.

## How was this patch tested?

CI
